### PR TITLE
feat: add Server-Sent Events support for stream cat

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -163,7 +163,7 @@ async fn handle_stream_cat(
     let rx = store.read(options).await;
     let stream = ReceiverStream::new(rx);
 
-    let accept_type_clone = accept_type.clone(); // Clone here to use in the closure
+    let accept_type_clone = accept_type.clone();
     let stream = stream.map(move |frame| {
         let bytes = match accept_type_clone {
             AcceptType::Ndjson => {
@@ -175,7 +175,7 @@ async fn handle_stream_cat(
                 "event: {}\nid: {}\ndata: {}\n\n",
                 frame.topic,
                 frame.id,
-                serde_json::to_string(&frame.meta).unwrap_or_default()
+                serde_json::to_string(&frame).unwrap_or_default()
             )
             .into_bytes(),
         };

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,6 +51,7 @@ pub async fn cat(
     tail: bool,
     last_id: Option<String>,
     limit: Option<u64>,
+    sse: bool,
 ) -> Result<Receiver<Bytes>, BoxError> {
     let stream = connect(addr).await?;
     let io = TokioIo::new(stream);
@@ -91,10 +92,13 @@ pub async fn cat(
         "http://localhost/".to_string()
     };
 
-    let req = Request::builder()
-        .method(Method::GET)
-        .uri(uri)
-        .body(empty())?;
+    let mut req = Request::builder().method(Method::GET).uri(uri);
+
+    if sse {
+        req = req.header("Accept", "text/event-stream");
+    }
+
+    let req = req.body(empty())?;
 
     let res = sender.send_request(req).await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,10 @@ struct CommandCat {
     /// Limit the number of events
     #[clap(long)]
     limit: Option<u64>,
+
+    /// Use Server-Sent Events format
+    #[clap(long)]
+    sse: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -184,6 +188,7 @@ async fn cat(args: CommandCat) -> Result<(), Box<dyn std::error::Error + Send + 
         args.tail,
         args.last_id.clone(),
         args.limit,
+        args.sse,
     )
     .await?;
     let mut stdout = tokio::io::stdout();


### PR DESCRIPTION

- Adds Server-Sent Events (SSE) support to stream cat
- CLI: New `--sse` flag for `cat` command
- API: Responds to `Accept: text/event-stream` header
- Streams full frame data in SSE format:
  - event: topic
  - id: frame id
  - data: JSON-encoded full frame (including hash, but not the actual content)
- Enables real-time, push-based updates from server to client

<img width="870" alt="image" src="https://github.com/user-attachments/assets/5bf2b9a4-dd50-42db-8151-9fac51e42f68">

<img width="942" alt="image" src="https://github.com/user-attachments/assets/3996332a-0b49-4015-a1bc-64ec8d70a85b">



