### PR TITLE
feat(api): add --expose option for additional interface, keep default socket

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -324,8 +324,17 @@ pub async fn serve(
         .await;
 
     let path = store.path.join("sock").to_string_lossy().to_string();
-    let mut listener = Listener::bind(&path).await?;
+    let listener = Listener::bind(&path).await?;
 
+    listener_loop(listener, store, engine, pool).await
+}
+
+async fn listener_loop(
+    mut listener: Listener,
+    store: Store,
+    engine: nu::Engine,
+    pool: ThreadPool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     loop {
         let (stream, _) = listener.accept().await?;
         let io = TokioIo::new(stream);

--- a/src/api.rs
+++ b/src/api.rs
@@ -313,17 +313,18 @@ pub async fn serve(
     mut store: Store,
     engine: nu::Engine,
     pool: ThreadPool,
-    addr: &str,
+    expose: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let _ = store
         .append(
             Frame::with_topic("xs.start")
-                .meta(serde_json::json!({"addr": addr}))
+                .meta(serde_json::json!({"expose": expose}))
                 .build(),
         )
         .await;
 
-    let mut listener = Listener::bind(addr).await?;
+    let path = store.path.join("sock").to_string_lossy().to_string();
+    let mut listener = Listener::bind(&path).await?;
 
     loop {
         let (stream, _) = listener.accept().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,11 +36,10 @@ struct CommandServe {
     #[clap(value_parser)]
     path: PathBuf,
 
-    /// Overrides the default address the API listens on.
-    /// Default is a Unix domain socket 'sock' in the store path.
-    /// Address to listen on [HOST]:PORT or <PATH> for Unix domain socket
+    /// Exposes the API on an additional address.
+    /// Can be [HOST]:PORT for TCP or <PATH> for Unix domain socket
     #[clap(long, value_parser, value_name = "LISTEN_ADDR")]
-    api: Option<String>,
+    expose: Option<String>,
 
     /// Enables a HTTP endpoint.
     /// Address to listen on [HOST]:PORT or <PATH> for Unix domain socket
@@ -171,10 +170,7 @@ async fn serve(args: CommandServe) -> Result<(), Box<dyn std::error::Error + Sen
     }
 
     // TODO: graceful shutdown
-    let addr = args
-        .api
-        .unwrap_or_else(|| store.path.join("sock").to_string_lossy().to_string());
-    xs::api::serve(store, engine.clone(), pool.clone(), &addr).await?;
+    xs::api::serve(store, engine.clone(), pool.clone(), args.expose).await?;
     pool.wait_for_completion();
 
     Ok(())


### PR DESCRIPTION
- Replace --api option with --expose
- Keep default Unix socket at store/sock
- --expose adds optional second listener (Unix or TCP)
- Refactor serve() to handle multiple listeners concurrently

```nushell
xs serve ./store --expose :3030
```

<img width="873" alt="image" src="https://github.com/user-attachments/assets/6455f150-a67c-42f2-bc9d-ac066de26d6f">

<img width="867" alt="image" src="https://github.com/user-attachments/assets/03a54b59-423e-4da1-853f-03d1c1416f1c">
