### PR TITLE
feat: topic secondary index

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -83,7 +83,7 @@ impl HandlerTask {
 }
 
 async fn spawn(
-    mut store: Store,
+    store: Store,
     handler: HandlerTask,
     pool: ThreadPool,
 ) -> Result<tokio::sync::mpsc::Sender<bool>, Error> {
@@ -91,7 +91,7 @@ async fn spawn(
 
     let last_id: Option<Scru128Id> = if let Some(start) = handler.meta.start.as_ref() {
         match start {
-            StartDefinition::Head { head } => store.head(head.to_string()).map(|frame| frame.id),
+            StartDefinition::Head { head } => store.head(head).map(|frame| frame.id),
         }
     } else {
         None
@@ -110,7 +110,7 @@ async fn spawn(
     let mut recver = store.read(options).await;
 
     {
-        let mut store = store.clone();
+        let store = store.clone();
         let mut handler = handler.clone();
         let mut generated_frames = std::collections::HashSet::new();
 
@@ -139,9 +139,9 @@ async fn spawn(
 
                 let value = execute_and_get_result(&pool, handler.clone(), frame.clone()).await;
                 if handler.meta.stateful.unwrap_or(false) {
-                    handle_result_stateful(&mut store, &mut handler, &frame, value).await;
+                    handle_result_stateful(&store, &mut handler, &frame, value).await;
                 } else if let Some(frame_id) =
-                    handle_result_stateless(&mut store, &handler, &frame, value).await
+                    handle_result_stateless(&store, &handler, &frame, value).await
                 {
                     generated_frames.insert(frame_id);
                 }
@@ -208,7 +208,7 @@ fn execute_handler(handler: HandlerTask, frame: &Frame) -> Result<Value, Error> 
 }
 
 async fn handle_result_stateful(
-    store: &mut Store,
+    store: &Store,
     handler: &mut HandlerTask,
     frame: &Frame,
     value: Value,
@@ -242,7 +242,7 @@ async fn handle_result_stateful(
 }
 
 async fn handle_result_stateless(
-    store: &mut Store,
+    store: &Store,
     handler: &HandlerTask,
     frame: &Frame,
     value: Value,
@@ -330,7 +330,7 @@ mod tests {
     #[tokio::test]
     async fn test_serve_stateless() {
         let temp_dir = TempDir::new().unwrap();
-        let mut store = Store::new(temp_dir.into_path()).await;
+        let store = Store::new(temp_dir.into_path()).await;
         let pool = ThreadPool::new(4);
         let engine = nu::Engine::new(store.clone()).unwrap();
 
@@ -397,7 +397,7 @@ mod tests {
     #[tokio::test]
     async fn test_serve_stateful() {
         let temp_dir = TempDir::new().unwrap();
-        let mut store = Store::new(temp_dir.into_path()).await;
+        let store = Store::new(temp_dir.into_path()).await;
         let pool = ThreadPool::new(4);
         let engine = nu::Engine::new(store.clone()).unwrap();
 
@@ -478,7 +478,7 @@ mod tests {
     #[tokio::test]
     async fn test_handler_update() {
         let temp_dir = TempDir::new().unwrap();
-        let mut store = Store::new(temp_dir.into_path()).await;
+        let store = Store::new(temp_dir.into_path()).await;
         let pool = ThreadPool::new(4);
         let engine = nu::Engine::new(store.clone()).unwrap();
 
@@ -604,7 +604,7 @@ mod tests {
     // This test is to ensure that a handler does not process its own output
     async fn test_handler_stateless_no_self_loop() {
         let temp_dir = TempDir::new().unwrap();
-        let mut store = Store::new(temp_dir.into_path()).await;
+        let store = Store::new(temp_dir.into_path()).await;
         let pool = ThreadPool::new(4);
         let engine = nu::Engine::new(store.clone()).unwrap();
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -58,7 +58,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 type HTTPResult = Result<hyper::Response<BoxBody<Bytes, BoxError>>, BoxError>;
 
 async fn handle(
-    mut store: Store,
+    store: Store,
     req: hyper::Request<hyper::body::Incoming>,
     addr: Option<SocketAddr>,
     connection_id: Scru128Id,
@@ -234,7 +234,7 @@ pub async fn serve(
             let mut streams = active_streams.lock().await;
             if let Some(requests) = streams.untrack_connection(&connection_id) {
                 for request_id in requests {
-                    let mut store = store.clone();
+                    let store = store.clone();
                     let _ = store
                         .append(
                             Frame::with_topic("http.disconnect")

--- a/src/nu/commands/append_command.rs
+++ b/src/nu/commands/append_command.rs
@@ -57,7 +57,7 @@ impl Command for AppendCommand {
     ) -> Result<PipelineData, ShellError> {
         let span = call.head;
 
-        let mut store = self.store.clone();
+        let store = self.store.clone();
 
         let topic: String = call.req(engine_state, stack, 0)?;
         let meta: Option<Value> = call.get_flag(engine_state, stack, "meta")?;

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -122,7 +122,7 @@ pub async fn serve(
             )
             .await
             {
-                let mut store = store.clone();
+                let store = store.clone();
                 let meta = serde_json::json!({
                     "source_id": frame.id.to_string(),
                     "reason": e.to_string()
@@ -143,7 +143,7 @@ pub async fn serve(
 }
 
 async fn append(
-    mut store: Store,
+    store: Store,
     source_id: Scru128Id,
     topic: &str,
     postfix: &str,
@@ -281,7 +281,7 @@ mod tests {
     #[tokio::test]
     async fn test_serve_basic() {
         let temp_dir = TempDir::new().unwrap();
-        let mut store = Store::new(temp_dir.into_path()).await;
+        let store = Store::new(temp_dir.into_path()).await;
         let engine = nu::Engine::new(store.clone()).unwrap();
 
         {
@@ -336,7 +336,7 @@ mod tests {
     #[tokio::test]
     async fn test_serve_duplex() {
         let temp_dir = TempDir::new().unwrap();
-        let mut store = Store::new(temp_dir.into_path()).await;
+        let store = Store::new(temp_dir.into_path()).await;
         let engine = nu::Engine::new(store.clone()).unwrap();
 
         {
@@ -388,7 +388,7 @@ mod tests {
     #[tokio::test]
     async fn test_serve_compact() {
         let temp_dir = TempDir::new().unwrap();
-        let mut store = Store::new(temp_dir.into_path()).await;
+        let store = Store::new(temp_dir.into_path()).await;
         let engine = nu::Engine::new(store.clone()).unwrap();
 
         let _ = store


### PR DESCRIPTION
Conflict resolved version of PR created by @marvin-j97  #19 

- Added secondary index partition for topics
- Write to index in `Store::append` as well, using write batch
- Index key uses topic + 0xFF + frame ID as encoding
- Removed mut condition from `Store::append`
- Use topic index in `Store::head`
- Added basic `head` test
- Change `Store::head` to only need topic as &str (no heap allocation)