### PR TITLE
feat: add "commands": a mechanism for one-shot, streaming, parallelized operations

### DIFF
--- a/docs/src/content/docs/getting-started/concepts.mdx
+++ b/docs/src/content/docs/getting-started/concepts.mdx
@@ -5,10 +5,10 @@ sidebar:
   order: 3
 ---
 
-cross.stream is built around three fundamental concepts that work together to
+cross.stream is built around four fundamental concepts that work together to
 create a powerful and flexible event streaming system: the event store,
-generators, and handlers. Let's explore how these components interact and
-complement each other.
+generators, handlers, and commands. Let's explore how these components interact
+and complement each other.
 
 ## Event Store: The Foundation
 
@@ -30,7 +30,9 @@ This design makes the event store particularly good at maintaining an accurate
 history of what happened and when, while still being efficient to query and
 process.
 
-## Generators: The Producers
+## Processing Components
+
+### Generators: The Producers
 
 Generators are like automated watchers that produce new events into the stream.
 They run as background processes, monitoring for specific conditions or changes
@@ -42,75 +44,80 @@ For example, a generator might:
 - Monitor a websocket connection and turn incoming messages into events
 - Periodically check a system's status and emit health events
 
-What makes generators powerful is their ability to:
+### Handlers: The Reactors
 
-- Run continuously in the background
-- Automatically restart if they encounter issues
-- Handle bi-directional communication when needed (with the `duplex` option)
-- Emit standardized lifecycle events (start, stop, error)
+Handlers provide a way to react to and process events in the stream. They are
+like event-driven functions that wake up when new events arrive, process them
+according to rules you define, and optionally produce new events in response.
 
-Think of generators as the sensors of your system - they watch, listen, and
-report what they observe into the event stream.
-
-## Handlers: The Reactors
-
-Handlers complete the picture by providing a way to react to and process events
-in the stream. They are like event-driven functions that wake up when new events
-arrive, process them according to rules you define, and optionally produce new
-events in response.
-
-Key characteristics of handlers include:
-
-- They process events using Nushell expressions
-- They can maintain state between executions
-- They can emit new events into the stream
-- They automatically track which events they've processed
-
-Handlers turn your event store from a passive recording system into an active
-processing pipeline. They can:
+A handler might:
 
 - Transform events into new formats
 - Trigger external actions in response to events
 - Aggregate or analyze event data
 - Create chains of event processing
 
-## How They Work Together
+### Commands: The On-demand Processors
 
-These three concepts form a powerful event processing system:
+Commands are reusable operations that can be called on-demand with input data.
+Unlike generators which run continuously, or handlers which maintain state,
+commands are stateless and execute independently each time they are called.
 
-1. The **event store** provides the reliable foundation, ensuring events are
-   durably stored and efficiently retrievable
-2. **Generators** feed the system with events from external sources
-3. **Handlers** process those events, potentially generating new events that
-   feed back into the system
+A command might:
 
-This creates a flexible architecture where:
+- Make an HTTP request and stream back SSE responses
+- Transform input data in a complex way
+- Interact with external services
 
-- Multiple generators can feed events into the system
-- Multiple handlers can process the same events in different ways
-- The event store ensures everything is reliably recorded and retrievable
+## Component Comparison
+
+| Aspect           | Generators                           | Handlers                      | Commands                     |
+| ---------------- | ------------------------------------ | ----------------------------- | ---------------------------- |
+| Purpose          | Produce events from external sources | Process existing events       | Perform on-demand operations |
+| Execution        | Continuous background process        | Event-driven                  | Called on-demand             |
+| State            | Stateless                            | Maintains state between calls | Stateless                    |
+| Output           | Immediate streaming                  | Buffered until completion     | Immediate streaming          |
+| Error Handling   | Auto-restarts                        | Unregisters                   | Per-invocation               |
+| Typical Use Case | Watch external sources               | Transform/react to events     | Reusable operations          |
+
+## Incremental Adoption
+
+One of the strengths of cross.stream's design is that you can start simple and
+gradually add complexity as needed:
+
+1. **Start with the Event Store**
+   - Begin by just using the store to record and query events
+   - Get comfortable with the basic append/read operations
+   - Use it like a specialized database
+
+2. **Add Generators**
+   - When you need to automatically capture events from external sources
+   - Start with simple file watchers or API monitors
+   - Let generators feed your event stream
+
+3. **Introduce Handlers**
+   - As you need to process or react to events
+   - Start with simple transformations
+   - Build up to more complex event processing chains
+
+4. **Define Commands**
+   - When you need reusable, on-demand operations
+   - Encapsulate common operations
+   - Use for streaming interactions with external services
+
+## Working Together
+
+These components create a flexible architecture where:
+
+1. **Generators** feed events into the system from external sources
+2. **Handlers** process those events, maintaining state if needed
+3. **Commands** provide reusable operations that can be called on-demand
+4. The **event store** ensures everything is reliably recorded and retrievable
 
 For example, you might have:
 
-- A generator watching a log file
-- A handler that filters for error events and creates alerts
-- Another handler that aggregates statistics
-- A third handler that archives old events
-
-Each component focuses on its specific role while working together to create a
-complete event processing system.
-
-## Choosing the Right Approach
-
-When working with cross.stream, consider:
-
-- Use the **event store directly** when you need to manually record events or
-  query the history
-- Use **generators** when you need to automatically produce events from external
-  sources
-- Use **handlers** when you need to process, transform, or react to events in
-  the stream
-
-The beauty of this design is that you can start simple - perhaps just using the
-event store directly - and gradually add generators and handlers as your needs
-grow more complex.
+- A generator watching system metrics
+- A handler that processes those metrics and detects anomalies
+- A command that can be called to fetch additional data when an anomaly is
+  detected
+- The event store maintaining the complete history of metrics and analysis

--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -2,7 +2,7 @@
 title: Architecture
 description: "A technical overview of cross.stream's decoupled architecture, explaining how it separates event metadata and content storage to optimize stream processing and content retrieval"
 sidebar:
-  order: 4
+  order: 5
 ---
 
 import { Link } from '../../../utils/links';

--- a/docs/src/content/docs/reference/commands.mdx
+++ b/docs/src/content/docs/reference/commands.mdx
@@ -1,6 +1,6 @@
 ---
 title: Commands
-description: TBD
+description: Stateless, parallelizable operations that can be called on-demand with streaming results
 sidebar:
   order: 4
 ---

--- a/docs/src/content/docs/reference/commands.mdx
+++ b/docs/src/content/docs/reference/commands.mdx
@@ -1,0 +1,82 @@
+---
+title: Commands
+description: TBD
+sidebar:
+  order: 4
+---
+
+import { Link } from '../../../utils/links';
+
+cross.stream commands use <Link to="nu" /> expressions to define reusable
+operations that can be called on-demand with arguments. Unlike handlers which
+maintain state between invocations, or generators which run continuously,
+commands are stateless and execute independently each time they are called.
+
+## Defining Commands
+
+To create a command, append a definition string with the topic
+`<command-name>.define`:
+
+```nushell
+r#"{
+  process: {|args|
+    # $in is implicitly available
+    # $args comes from closure parameter
+    http post --stream $args.url $in | parse lines
+  }
+}"# | .append stream.define
+```
+
+The command definition requires:
+
+- `process`: A closure that receives arguments and has access to input via `$in`
+
+Each value in the closure's output pipeline becomes a `.recv` event
+automatically.
+
+## Calling Commands
+
+Commands are called by appending to `<command-name>.call` with arguments in
+metadata:
+
+```nushell
+# Post $in to URL and stream SSE response
+$in | .append stream.call --meta {args: {url: "https://api.example.com/events"}}
+```
+
+## Lifecycle Events
+
+Commands emit events to track their execution:
+
+| Event                | Description                              |
+| -------------------- | ---------------------------------------- |
+| `<command>.recv`     | Output value from the command's pipeline |
+| `<command>.complete` | Command execution finished successfully  |
+| `<command>.error`    | Error occurred during command execution  |
+
+All events include:
+
+- `command_id`: ID of the command definition
+- `frame_id`: ID of this specific invocation
+
+## Error Handling
+
+If a command encounters an error during execution, it will:
+
+1. Emit a `<command>.error` frame with:
+   - The error message
+   - Reference to both command_id and frame_id
+2. Stop processing the current invocation
+
+Unlike generators, commands do not automatically restart on error - each
+invocation is independent.
+
+## Key Differences
+
+| Feature        | Commands                | Handlers               | Generators      |
+| -------------- | ----------------------- | ---------------------- | --------------- |
+| State          | Stateless               | Stateful between calls | Stateless       |
+| Execution      | On-demand               | Event-driven           | Continuous      |
+| Results        | Streamed immediately    | Batched on completion  | Streamed        |
+| Parallelism    | Multiple parallel calls | Sequential processing  | Single instance |
+| Error Handling | Per-invocation          | Unregisters handler    | Auto-restarts   |

--- a/docs/src/content/docs/reference/commands.mdx
+++ b/docs/src/content/docs/reference/commands.mdx
@@ -18,7 +18,7 @@ To create a command, append a definition string with the topic
 `<command-name>.define`:
 
 ```nushell
-r#"{
+r#'{
   process: {|frame|
     # frame.topic - always <command>.call
     # frame.hash - contains input content if present
@@ -27,7 +27,7 @@ r#"{
     let n = $frame.meta.args.n
     1..($n) | each {$"($in): ($input)"}
   }
-}"# | .append repeat.define
+}'# | .append repeat.define
 ```
 
 The command definition requires:

--- a/docs/src/content/docs/reference/commands.mdx
+++ b/docs/src/content/docs/reference/commands.mdx
@@ -19,29 +19,33 @@ To create a command, append a definition string with the topic
 
 ```nushell
 r#"{
-  process: {|args|
-    # $in is implicitly available
-    # $args comes from closure parameter
-    http post --stream $args.url $in | parse lines
+  process: {|frame|
+    # frame.topic - always <command>.call
+    # frame.hash - contains input content if present
+    # frame.meta.args - contains call arguments
+    let input = if ($frame.hash != null) { .cas $frame.hash } else { null }
+    let n = $frame.meta.args.n
+    1..($n) | each {$"($in): ($input)"}
   }
-}"# | .append stream.define
+}"# | .append repeat.define
 ```
 
 The command definition requires:
 
-- `process`: A closure that receives arguments and has access to input via `$in`
+- `process`: A closure that receives the call frame and can return a pipeline of
+  results
 
 Each value in the closure's output pipeline becomes a `.recv` event
 automatically.
 
 ## Calling Commands
 
-Commands are called by appending to `<command-name>.call` with arguments in
-metadata:
+Commands are called by appending to `<command-name>.call` with input content and
+arguments:
 
 ```nushell
-# Post $in to URL and stream SSE response
-$in | .append stream.call --meta {args: {url: "https://api.example.com/events"}}
+# Call the repeat command with input and args
+"foo" | .append repeat.call --meta {args: {n: 3}}
 ```
 
 ## Lifecycle Events

--- a/docs/src/content/docs/reference/import-export.mdx
+++ b/docs/src/content/docs/reference/import-export.mdx
@@ -2,7 +2,7 @@
 title: Import & Export
 description: "How to export and import data between cross.stream stores"
 sidebar:
-  order: 5
+  order: 6
 ---
 
 The supervisor exposes two endpoints to facilitate data transfer between stores:

--- a/docs/src/content/docs/reference/supervisor-api.mdx
+++ b/docs/src/content/docs/reference/supervisor-api.mdx
@@ -2,7 +2,7 @@
 title: HTTP API
 description: "Complete reference for the cross.stream supervisor's HTTP API"
 sidebar:
-  order: 6
+  order: 7
 ---
 
 The supervisor exposes a HTTP API for interacting with the store. By default, it

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,3 +2,5 @@ mod serve;
 
 #[cfg(test)]
 mod tests;
+
+pub use serve::serve;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,4 @@
+mod serve;
+
+#[cfg(test)]
+mod tests;

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,0 +1,205 @@
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+use scru128::Scru128Id;
+use tracing::instrument;
+
+use crate::error::Error;
+use crate::nu;
+use crate::nu::commands;
+use crate::nu::util::value_to_json;
+use crate::store::{FollowOption, Frame, ReadOptions, Store};
+
+struct Command {
+    id: Scru128Id,
+    engine: nu::Engine,
+    closure: nu_protocol::engine::Closure,
+}
+
+pub async fn serve(
+    store: Store,
+    mut base_engine: nu::Engine,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Add core commands to base engine
+    base_engine.add_commands(vec![
+        Box::new(commands::append_command::AppendCommand::new(store.clone())),
+    ])?;
+
+    let options = ReadOptions::builder().follow(FollowOption::On).build();
+    let mut recver = store.read(options).await;
+    let mut commands = HashMap::new();
+
+    while let Some(frame) = recver.recv().await {
+        if let Some(name) = frame.topic.strip_suffix(".define") {
+            match register_command(&frame, &base_engine, name, &store).await {
+                Ok(command) => {
+                    commands.insert(name.to_string(), command);
+                }
+                Err(err) => {
+                    let _ = store.append(
+                        Frame::with_topic(format!("{}.error", name))
+                            .meta(serde_json::json!({
+                                "command_id": frame.id.to_string(),
+                                "error": err.to_string(),
+                            }))
+                            .build(),
+                    );
+                }
+            }
+        } else if let Some(name) = frame.topic.strip_suffix(".call") {
+            if let Some(command) = commands.get(name) {
+                execute_command(command.clone(), frame, &store).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn register_command(
+    frame: &Frame,
+    base_engine: &nu::Engine,
+    name: &str,
+    store: &Store,
+) -> Result<Command, Error> {
+    // Get definition from CAS
+    let hash = frame.hash.as_ref().ok_or("Missing hash field")?;
+    let definition = store.cas_read(hash).await?;
+    let definition = String::from_utf8(definition)?;
+
+    // Parse definition and extract closure
+    let mut engine = base_engine.clone();
+    let (closure, _config) = parse_command_definition(&mut engine, &definition)?;
+
+    Ok(Command {
+        id: frame.id,
+        engine,
+        closure,
+    })
+}
+
+#[instrument(
+    level = "info",
+    skip(command, frame, store),
+    fields(
+        message = %format!(
+            "command={} frame={}:{}",
+            command.id, frame.id, frame.topic
+        )
+    )
+)]
+async fn execute_command(
+    command: Command,
+    frame: Frame,
+    store: &Store,
+) -> Result<(), Error> {
+    // Get input from CAS if present
+    let input = if let Some(hash) = frame.hash.as_ref() {
+        let content = store.cas_read(hash).await?;
+        let content = String::from_utf8(content)?;
+        serde_json::from_str(&content)?
+    } else {
+        serde_json::Value::Null
+    };
+
+    // Get args from meta
+    let args = frame.meta
+        .as_ref()
+        .and_then(|m| m.get("args"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Object(Default::default()));
+
+    let (tx, mut rx) = mpsc::channel(32);
+
+    // Spawn thread to run command
+    let topic = frame.topic.clone();
+    let store = store.clone();
+    
+    tokio::task::spawn_blocking(move || {
+        let Command { engine, closure, id: command_id } = command;
+        
+        match run_command(engine, closure, input, args) {
+            Ok(pipeline_data) => {
+                // Stream each value as a .recv event
+                for value in pipeline_data {
+                    if let Err(_) = tx.blocking_send((command_id, frame.id.clone(), value)) {
+                        break;
+                    }
+                }
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    });
+
+    // Process output stream
+    while let Some((command_id, frame_id, value)) = rx.recv().await {
+        let hash = store.cas_insert(&value_to_json(&value).to_string()).await?;
+        let _ = store.append(
+            Frame::with_topic(format!("{}.recv", topic.strip_suffix(".call").unwrap()))
+                .hash(hash)
+                .meta(serde_json::json!({
+                    "command_id": command_id.to_string(),
+                    "frame_id": frame_id.to_string(),
+                }))
+                .build(),
+        );
+    }
+
+    // Emit completion event
+    let _ = store.append(
+        Frame::with_topic(format!("{}.complete", topic.strip_suffix(".call").unwrap()))
+            .meta(serde_json::json!({
+                "command_id": command.id.to_string(),
+                "frame_id": frame.id.to_string(),
+            }))
+            .build(),
+    );
+
+    Ok(())
+}
+
+fn run_command(
+    mut engine: nu::Engine,
+    closure: nu_protocol::engine::Closure,
+    input: serde_json::Value,
+    args: serde_json::Value,
+) -> Result<Vec<nu_protocol::Value>, Error> {
+    // Set up engine state
+    let mut stack = nu_protocol::engine::Stack::new();
+    
+    // Convert input and args to Nu values and add to stack
+    let input_value = crate::nu::json_to_value(&input)?;
+    let args_value = crate::nu::json_to_value(&args)?;
+    
+    stack.add_var("in".into(), input_value);
+    
+    let block = engine.state.get_block(closure.block_id);
+    let frame_var_id = block.signature.required_positional[0].var_id.unwrap();
+    stack.add_var(frame_var_id, args_value);
+
+    // Execute closure
+    let result = nu_engine::eval_block_with_early_return::<nu_protocol::debugger::WithoutDebug>(
+        &engine.state,
+        &mut stack,
+        block,
+        nu_protocol::PipelineData::empty(),
+    )?;
+
+    // Collect all values from pipeline
+    let mut values = Vec::new();
+    for value in result.into_iter() {
+        values.push(value);
+    }
+
+    Ok(values)
+}
+
+// Helper to parse command definition similar to handlers
+fn parse_command_definition(
+    engine: &mut nu::Engine,
+    script: &str,
+) -> Result<(nu_protocol::engine::Closure, serde_json::Value), Error> {
+    // Similar to parse_handler_configuration_script but simpler
+    // Just need to get the closure from the process field
+    todo!()
+}

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -20,9 +20,14 @@ pub async fn serve(
     mut base_engine: nu::Engine,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Add core commands to base engine
-    base_engine.add_commands(vec![Box::new(
-        commands::append_command::AppendCommand::new(store.clone()),
-    )])?;
+    base_engine.add_commands(vec![
+        Box::new(commands::cas_command::CasCommand::new(store.clone())),
+        Box::new(commands::cat_command::CatCommand::new(store.clone())),
+        Box::new(commands::get_command::GetCommand::new(store.clone())),
+        Box::new(commands::head_command::HeadCommand::new(store.clone())),
+        Box::new(commands::remove_command::RemoveCommand::new(store.clone())),
+        Box::new(commands::append_command::AppendCommand::new(store.clone())),
+    ])?;
 
     let options = ReadOptions::builder().follow(FollowOption::On).build();
     let mut recver = store.read(options).await;

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -1,0 +1,140 @@
+use tempfile::TempDir;
+
+use crate::error::Error;
+use crate::store::{FollowOption, Frame, ReadOptions, Store};
+use crate::nu;
+
+#[tokio::test]
+async fn test_command_with_pipeline() -> Result<(), Error> {
+    let (store, _temp_dir) = setup_test_environment().await;
+    let options = ReadOptions::builder().follow(FollowOption::On).build();
+    let mut recver = store.read(options).await;
+    assert_eq!(recver.recv().await.unwrap().topic, "xs.threshold");
+
+    // Define the command
+    let frame_command = store.append(
+        Frame::with_topic("echo.define")
+            .hash(
+                store
+                    .cas_insert(
+                        r#"{
+                            process: {|args| 
+                                let s = $in
+                                1..($args.n) | each {$"($in): ($s)"}
+                            }
+                        }"#,
+                    )
+                    .await?,
+            )
+            .build(),
+    );
+    assert_eq!(recver.recv().await.unwrap().topic, "echo.define");
+
+    // Call the command
+    let frame_call = store.append(
+        Frame::with_topic("echo.call")
+            .hash(store.cas_insert(r#""foo""#).await?)
+            .meta(serde_json::json!({"args": {"n": 3}}))
+            .build(),
+    );
+    assert_eq!(recver.recv().await.unwrap().topic, "echo.call");
+
+    // Validate the output events
+    let expected = vec!["1: foo", "2: foo", "3: foo"];
+    for expected_content in expected {
+        let frame = recver.recv().await.unwrap();
+        assert_eq!(frame.topic, "echo.recv");
+        let meta = frame.meta.as_ref().expect("Meta should be present");
+        assert_eq!(meta["command_id"], frame_command.id.to_string());
+        assert_eq!(meta["frame_id"], frame_call.id.to_string());
+        
+        // Verify content
+        let content = store.cas_read(&frame.hash.unwrap()).await?;
+        let content_str = String::from_utf8(content)?;
+        assert_eq!(content_str, format!("\"{}\"", expected_content));
+    }
+
+    // Should get completion event
+    let frame = recver.recv().await.unwrap();
+    assert_eq!(frame.topic, "echo.complete");
+    let meta = frame.meta.as_ref().expect("Meta should be present");
+    assert_eq!(meta["command_id"], frame_command.id.to_string());
+    assert_eq!(meta["frame_id"], frame_call.id.to_string());
+
+    assert_no_more_frames(&mut recver).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_command_error_handling() -> Result<(), Error> {
+    let (store, _temp_dir) = setup_test_environment().await;
+    let options = ReadOptions::builder().follow(FollowOption::On).build();
+    let mut recver = store.read(options).await;
+    assert_eq!(recver.recv().await.unwrap().topic, "xs.threshold");
+
+    // Define command that will error with invalid args
+    let frame_command = store.append(
+        Frame::with_topic("will_error.define")
+            .hash(
+                store
+                    .cas_insert(
+                        r#"{
+                            process: {|args| 
+                                1..($args.not_exists) # This will error
+                            }
+                        }"#,
+                    )
+                    .await?,
+            )
+            .build(),
+    );
+    assert_eq!(recver.recv().await.unwrap().topic, "will_error.define");
+
+    // Call the command
+    let frame_call = store.append(
+        Frame::with_topic("will_error.call")
+            .hash(store.cas_insert(r#""input""#).await?)
+            .meta(serde_json::json!({"args": {}}))
+            .build(),
+    );
+    assert_eq!(recver.recv().await.unwrap().topic, "will_error.call");
+
+    // Should get error event
+    let frame = recver.recv().await.unwrap();
+    assert_eq!(frame.topic, "will_error.error");
+    let meta = frame.meta.as_ref().expect("Meta should be present");
+    assert_eq!(meta["command_id"], frame_command.id.to_string());
+    assert_eq!(meta["frame_id"], frame_call.id.to_string());
+    assert!(meta["error"].as_str().unwrap().contains("not_exists"));
+
+    assert_no_more_frames(&mut recver).await;
+    Ok(())
+}
+
+async fn assert_no_more_frames(recver: &mut tokio::sync::mpsc::Receiver<Frame>) {
+    let timeout = tokio::time::sleep(std::time::Duration::from_millis(50));
+    tokio::pin!(timeout);
+    tokio::select! {
+        Some(frame) = recver.recv() => {
+            panic!("Unexpected frame processed: {:?}", frame);
+        }
+        _ = &mut timeout => {
+            // Success - no additional frames were processed
+        }
+    }
+}
+
+async fn setup_test_environment() -> (Store, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let store = Store::new(temp_dir.path().to_path_buf());
+    let engine = nu::Engine::new().unwrap();
+
+    {
+        let store = store.clone();
+        let _ = tokio::spawn(async move {
+            crate::serve(store, engine).await.unwrap();
+        });
+    }
+
+    (store, temp_dir)
+}

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -34,7 +34,7 @@ async fn test_command_with_pipeline() -> Result<(), Error> {
     // Call the command
     let frame_call = store.append(
         Frame::with_topic("echo.call")
-            .hash(store.cas_insert(r#""foo""#).await?)
+            .hash(store.cas_insert(r#"foo"#).await?)
             .meta(serde_json::json!({"args": {"n": 3}}))
             .build(),
     );
@@ -52,7 +52,10 @@ async fn test_command_with_pipeline() -> Result<(), Error> {
         // Verify content
         let content = store.cas_read(&frame.hash.unwrap()).await?;
         let content_str = String::from_utf8(content)?;
-        assert_eq!(content_str, format!("\"{}\"", expected_content));
+        assert_eq!(
+            content_str,
+            serde_json::to_string(expected_content).unwrap()
+        );
     }
 
     // Should get completion event

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -1,8 +1,8 @@
 use tempfile::TempDir;
 
 use crate::error::Error;
-use crate::store::{FollowOption, Frame, ReadOptions, Store};
 use crate::nu;
+use crate::store::{FollowOption, Frame, ReadOptions, Store};
 
 #[tokio::test]
 async fn test_command_with_pipeline() -> Result<(), Error> {
@@ -18,7 +18,7 @@ async fn test_command_with_pipeline() -> Result<(), Error> {
                 store
                     .cas_insert(
                         r#"{
-                            process: {|args| 
+                            process: {|args|
                                 let s = $in
                                 1..($args.n) | each {$"($in): ($s)"}
                             }
@@ -47,7 +47,7 @@ async fn test_command_with_pipeline() -> Result<(), Error> {
         let meta = frame.meta.as_ref().expect("Meta should be present");
         assert_eq!(meta["command_id"], frame_command.id.to_string());
         assert_eq!(meta["frame_id"], frame_call.id.to_string());
-        
+
         // Verify content
         let content = store.cas_read(&frame.hash.unwrap()).await?;
         let content_str = String::from_utf8(content)?;
@@ -79,7 +79,7 @@ async fn test_command_error_handling() -> Result<(), Error> {
                 store
                     .cas_insert(
                         r#"{
-                            process: {|args| 
+                            process: {|args|
                                 1..($args.not_exists) # This will error
                             }
                         }"#,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod client;
+pub mod commands;
 pub mod error;
 pub mod handlers;
 pub mod http;

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,6 +210,14 @@ async fn serve(args: CommandServe) -> Result<(), Box<dyn std::error::Error + Sen
         });
     }
 
+    {
+        let store = store.clone();
+        let engine = engine.clone();
+        tokio::spawn(async move {
+            let _ = xs::commands::serve(store, engine).await;
+        });
+    }
+
     if let Some(addr) = args.http {
         let store = store.clone();
         tokio::spawn(async move {


### PR DESCRIPTION
Commands provide a way to define reusable, stateless operations that:
- Execute on-demand with arguments and optional input
- Stream results via .recv events
- Can run multiple instances in parallel
- Handle errors independently per invocation

Unlike handlers (stateful) or generators (continuous), commands are designed for 
discrete, parallelizable tasks with immediate streaming output.