### PR TITLE
docs(examples): update generator config format

### DIFF
--- a/examples/discord-bot/README.md
+++ b/examples/discord-bot/README.md
@@ -35,8 +35,10 @@ In another session:
 ```nushell
 use xs.nu *
 
-"websocat "wss://gateway.discord.gg/?v=10&encoding=json" --ping-interval 5 --ping-timeout 10 -E -t | lines" |
-    .append discord.ws.spawn --meta {duplex: true}
+{
+  run: {|| websocat "wss://gateway.discord.gg/?v=10&encoding=json" --ping-interval 5 --ping-timeout 10 -E -t | lines },
+  duplex: true
+} | .append discord.ws.spawn
 
 # append the access token to use to the stream
 "<token>" | .append discord.ws.token

--- a/examples/x-macos-pasteboard/README.md
+++ b/examples/x-macos-pasteboard/README.md
@@ -12,7 +12,7 @@ You can use it as a [generator](https://cablehead.github.io/xs/reference/generat
 contents of your pasteboard to an event stream.
 
 ```nushell
-"x-macos-pasteboard | lines" | .append pb.spawn
+{ run: {|| x-macos-pasteboard | lines } } | .append pb.spawn
 ```
 
 You can then subscribe to new pasteboard events with:

--- a/examples/x-macos-pasteboard/solid-ui/README.md
+++ b/examples/x-macos-pasteboard/solid-ui/README.md
@@ -23,7 +23,7 @@ Bootstrap the store:
 
 ```nushell
 # register x-macos-pasteboard as a frame generator
-"x-macos-pasteboard | lines" | .append pb.spawn
+{ run: {|| x-macos-pasteboard | lines } } | .append pb.spawn
 
 # register a handler to map raw clipboard data to content
 cat handler-pb.map.nu | .append pb.map.register
@@ -48,7 +48,7 @@ and dump as much data as the system will give you.
 Replace the bootstrap step with:
 
 ```bash
-echo "<your-cli> | lines" | xs append ./store pb.spawn
+echo '{ run: {|| <your-cli> | lines } }' | xs append ./store pb.spawn
 ```
 
 That's it! As you copy stuff to the clipboard, you'll see your raw data in the


### PR DESCRIPTION
## Summary
- update generator README examples to new `{run: {}}` format

## Testing
- `git status --short`