### PR TITLE
feat(generator): emit stop on spawn failure

### DIFF
--- a/src/generators/serve.rs
+++ b/src/generators/serve.rs
@@ -91,22 +91,22 @@ pub async fn serve(
             continue;
         }
 
-        if let Some(prefix) = frame.topic.strip_suffix(".spawn.error") {
-            let key = (prefix.to_string(), frame.context_id);
-            active.remove(&key);
+        if let Some(_prefix) = frame.topic.strip_suffix(".spawn.error") {
+            // spawn.error frames are informational; ignore them
             continue;
         }
 
         if let Some(prefix) = frame.topic.strip_suffix(".stop") {
-            let reason = frame
+            if let Some(reason) = frame
                 .meta
                 .as_ref()
                 .and_then(|m| m.get("reason"))
                 .and_then(|v| v.as_str())
-                .unwrap_or("");
-            if reason == "terminate" {
-                let key = (prefix.to_string(), frame.context_id);
-                active.remove(&key);
+            {
+                if reason == "terminate" || reason == "spawn.error" {
+                    let key = (prefix.to_string(), frame.context_id);
+                    active.remove(&key);
+                }
             }
             continue;
         }

--- a/src/generators/tests.rs
+++ b/src/generators/tests.rs
@@ -534,7 +534,15 @@ async fn test_spawn_error_eviction() {
 
     let err_frame = recver.recv().await.unwrap();
     assert_eq!(err_frame.topic, "oops.spawn.error");
-    println!("first error reason: {}", err_frame.meta.unwrap()["reason"]);
+    println!(
+        "first error reason: {}",
+        err_frame.meta.as_ref().unwrap()["reason"]
+    );
+
+    // expect a stop frame indicating the spawn error
+    let stop_frame = recver.recv().await.unwrap();
+    assert_eq!(stop_frame.topic, "oops.stop");
+    assert_eq!(stop_frame.meta.as_ref().unwrap()["reason"], "spawn.error");
 
     // Allow ServeLoop to process the spawn.error and evict the generator
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;


### PR DESCRIPTION
## Summary
- emit `{topic}.stop` when spawning a generator fails
- ignore `.spawn.error` in the ServeLoop and evict on `.stop` with reason `spawn.error`
- adjust tests for the new stop frame

## Testing
- `./scripts/check.sh`