### PR TITLE
feat(generator): handle hot reload and docs

### DIFF
--- a/docs/src/content/docs/reference/generators.mdx
+++ b/docs/src/content/docs/reference/generators.mdx
@@ -39,10 +39,10 @@ Generators emit lifecycle events to track their state:
 | --------------------- | --------------------------------------- |
 | `<topic>.start`       | Generator has started processing        |
 | `<topic>.recv`        | Output value from the generator         |
-| `<topic>.stop` | Generator pipeline has stopped. The \`meta.reason\` field is a string enum with values `finished`, `error` and `terminate`. When `finished` or `error`, the pipeline will be restarted automatically; `terminate` means it was stopped manually and the generator loop for this topic/context will shut down. |
+| `<topic>.stop` | Generator pipeline has stopped. The \`meta.reason\` field is a string enum with values `finished`, `error`, `terminate` and `update`. When `finished` or `error`, the pipeline will be restarted automatically; `terminate` means it was stopped manually and the generator loop for this topic/context will shut down. `update` indicates the generator reloaded due to a new `.spawn` frame. |
 | `<topic>.spawn.error` | Error occurred while spawning generator |
 
-All events include `source_id` which is the ID of the generator instance.
+All events include `source_id` which is the ID of the generator instance. When a `.stop` frame has `meta.reason` set to `update`, it also includes `update_id` referencing the spawn that triggered the reload.
 
 ## Configuration Options
 
@@ -89,5 +89,7 @@ To stop a running generator, append a frame with the topic `<topic>.terminate`.
 The generator will stop and emit a `<topic>.stop` frame with `meta.reason` set to
 `terminate`.
 
-Attempting to spawn a generator while another of the same topic and context is
-active will produce a `<topic>.spawn.error` frame.
+Appending a new `<topic>.spawn` frame while a generator of the same topic and
+context is running reloads it with the new script. If the reload fails to parse,
+you'll see a `<topic>.spawn.error` frame, and the previous generator continues
+running.

--- a/src/generators/serve.rs
+++ b/src/generators/serve.rs
@@ -45,7 +45,10 @@ async fn handle_spawn_event(
         if handle.is_finished() {
             active.remove(&key);
         } else {
-            return Err("Updating existing generator is not implemented".into());
+            // A generator for this topic/context is already running. Ignore the
+            // new spawn frame; the running generator will handle it as a hot
+            // reload.
+            return Ok(());
         }
     }
 


### PR DESCRIPTION
## Summary
- let running generator self-refresh when `.spawn` is received
- allow ServeLoop to ignore new spawns when generator is active
- document `update` stop reason and `update_id`

## Testing
- `./scripts/check.sh`
- `cd docs && npm run build`
