### PR TITLE
docs(generator): document spawn error stop

### DIFF
--- a/docs/src/content/docs/reference/generators.mdx
+++ b/docs/src/content/docs/reference/generators.mdx
@@ -83,6 +83,9 @@ is emitted with:
 - `source_id`: ID of the failed spawn attempt
 - `reason`: Error message describing what went wrong
 
+The generator also appends a `<topic>.stop` frame with `meta.reason` set to
+`spawn.error` so the failed instance can be cleaned up.
+
 ## Stopping Generators
 
 To stop a running generator, append a frame with the topic `<topic>.terminate`.

--- a/examples/x-macos-pasteboard/solid-ui/README.md
+++ b/examples/x-macos-pasteboard/solid-ui/README.md
@@ -22,7 +22,7 @@ xs serve ./store --expose :3021
 Bootstrap the store:
 
 ```nushell
-# register x-macos-pasteboard as a frame generator
+# register x-macos-pasteboard as a generator
 { run: {|| x-macos-pasteboard | lines } } | .append pb.spawn
 
 # register a handler to map raw clipboard data to content


### PR DESCRIPTION
## Summary
- mention `spawn.error` stop event in generator docs
- tweak clipboard example wording

## Testing
- `cd docs && npm run build`