### PR TITLE
docs: clarify store defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ xs serve ./store
 # in another window
 echo "hello" | xs append ./store notes
 xs cat ./store
+
+# the xs.nu helpers fall back to ~/.local/share/cross.stream/store
+# to use a different location temporarily:
+with-env {XS_ADDR: "./store"} { xs cat }
 ```
 
 ## Features

--- a/docs/src/content/docs/getting-started/first-stream.mdx
+++ b/docs/src/content/docs/getting-started/first-stream.mdx
@@ -27,12 +27,22 @@ Start an `xs` store in a dedicated window:
 
 ```bash withOutput
 > xs serve ./store
-13:35:16.868 TRACE         event src/main.rs:185 Starting server with path: "./store                                                                    xs:185
+13:35:16.868 TRACE         event src/main.rs:185 Starting server with path: "./store"                                                                    xs:185
 13:35:16.957  INFO         read options=ReadOptions { follow: On, tail: false, last_id: None, limit: None }                                      xs::store:174
 13:35:16.957  INFO         read options=ReadOptions { follow: On, tail: true, last_id: None, limit: None }                                       xs::store:174
 13:35:16.963  INFO     5ms insert_frame frame=Frame { id: "03d4por2p16i05i81fjy0fx8u", topic: "xs.start", hash: None, meta: None, ttl: None }    xs::store:410
 13:35:16.963 0fx8u xs.start
 13:35:16.968  INFO         read options=ReadOptions { follow: On, tail: false, last_id: None, limit: None }                                      xs::store:174
+```
+
+For a long-running setup you might run `xs serve ~/.local/share/cross.stream/store`
+under a process supervisor. This is also the fallback location used by
+`xs.nu` when `$env.XS_ADDR` isn't set. Here we keep the demo scoped to `./store`.
+
+To point tools at another store, set `XS_ADDR`. This can be done temporarily with `with-env`:
+
+```bash
+with-env {XS_ADDR: "./store"} { xs cat }
 ```
 
 ## Client

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -57,8 +57,16 @@ After installation, import the module:
 use xs.nu *
 ```
 
-The commands default to working with a `./store` in your current directory. You
-can customize this by setting `$env.XS_ADDR`.
+The commands default to working with a store at `~/.local/share/cross.stream/store`.
+You can point commands at another location by setting `$env.XS_ADDR`.
+For quick, ad-hoc changes use `with-env`:
+
+```nushell
+with-env {XS_ADDR: "./store"} { .cat }
+```
+
+The `xs` command-line tool still requires the store path to be specified
+explicitly (for example `xs serve ./store`).
 
 ## Troubleshooting
 

--- a/xs.nu
+++ b/xs.nu
@@ -21,7 +21,7 @@ def conditional-pipe [
 }
 
 export def xs-addr [] {
-  $env | get XS_ADDR? | or-else { try { open  ~/.config/cross.stream/XS_ADDR | str trim | path expand } } | or-else { "./store" }
+  $env | get XS_ADDR? | or-else { try { open  ~/.config/cross.stream/XS_ADDR | str trim | path expand } } | or-else { "~/.local/share/cross.stream/store" | path expand }
 }
 
 export def xs-context-collect [] {


### PR DESCRIPTION
## Summary
- document `xs` CLI examples with explicit store path
- explain the fallback store used by `xs.nu`
- mention that the CLI still requires the path

## Testing
- `cd ./docs && npm run build`
- `./scripts/check.sh`
