### PR TITLE
feat(generator): kill job by spawn id

### DIFF
--- a/src/generators/generator.rs
+++ b/src/generators/generator.rs
@@ -163,7 +163,7 @@ async fn run_loop(store: Store, mut task: GeneratorLoop, pristine: nu::Engine) {
                     match maybe {
                         Some(frame) if frame.topic == terminate_topic => {
                             task.engine.state.signals().trigger();
-                            task.engine.kill_all_jobs();
+                            task.engine.kill_job_by_name(&task.id.to_string());
                             let _ = (&mut done_rx).await;
                             reason = StopReason::Terminate;
                             break;
@@ -181,7 +181,7 @@ async fn run_loop(store: Store, mut task: GeneratorLoop, pristine: nu::Engine) {
                                                 new_engine.state.set_signals(Signals::new(interrupt.clone()));
 
                                                 task.engine.state.signals().trigger();
-                                                task.engine.kill_all_jobs();
+                                                task.engine.kill_job_by_name(&task.id.to_string());
                                                 let _ = (&mut done_rx).await;
 
                                                 reason = StopReason::Update;
@@ -314,7 +314,7 @@ fn spawn_thread(
             &task.run_closure,
             None,
             Some(input_pipeline),
-            format!("generator {}", task.topic),
+            task.id.to_string(),
         ) {
             Ok(pipeline) => {
                 match pipeline {

--- a/src/nu/engine.rs
+++ b/src/nu/engine.rs
@@ -315,12 +315,17 @@ impl Engine {
         eval_res.map_err(Box::new)
     }
 
-    /// Kill and remove every outstanding job.
-    pub fn kill_all_jobs(&self) {
+    /// Kill the background ThreadJob whose name equals `name`.
+    pub fn kill_job_by_name(&self, name: &str) {
         if let Ok(mut jobs) = self.state.jobs.lock() {
-            let ids: Vec<_> = jobs.iter().map(|(id, _)| id).collect();
-            for id in ids {
-                let _ = jobs.kill_and_remove(id);
+            let job_id = {
+                jobs.iter().find_map(|(jid, job)| {
+                    job.tag()
+                        .and_then(|tag| if tag == name { Some(jid) } else { None })
+                })
+            };
+            if let Some(job_id) = job_id {
+                let _ = jobs.kill_and_remove(job_id);
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `kill_job_by_name` helper to Engine
- name generator threads using spawn id
- terminate or reload only the matching generator thread
- test terminating one generator while another keeps running

## Testing
- `./scripts/check.sh`