### PR TITLE
docs(reference): update ephemeral TTL and generator output

### DIFF
--- a/docs/src/content/docs/reference/generators.mdx
+++ b/docs/src/content/docs/reference/generators.mdx
@@ -24,8 +24,8 @@ record with a `run` closure using the topic `<topic>.spawn`:
 The generator will:
 
 - Execute the provided Nushell expression
-- Each line written to `http.log` will be emitted as a frame with topic
-  `log.recv`
+- Output from the pipeline is streamed as `log.recv` frames. Text pipelines emit
+  one frame per line, while `ByteStream` pipelines send binary chunks.
 - Automatically restarts if it exits until a terminate frame is seen
 
 All frames produced by the generator use the same context as the `.spawn` frame

--- a/docs/src/content/docs/reference/handlers.mdx
+++ b/docs/src/content/docs/reference/handlers.mdx
@@ -95,7 +95,7 @@ The `return_options` field controls how return values are handled:
 - `suffix`: String appended to handler's name for output topic (default: ".out")
 - `ttl`: Time-to-live for output frames
   - `"forever"`: Never expire
-  - `"ephemeral"`: Remove after reading
+  - `"ephemeral"`: Not stored; only active subscribers receive it
   - `"time:<milliseconds>"`: Expire after duration
   - `"head:<n>"`: Keep only N most recent frames
 

--- a/docs/src/content/docs/reference/store-api.mdx
+++ b/docs/src/content/docs/reference/store-api.mdx
@@ -48,7 +48,7 @@ Query Parameters:
 
 - `ttl` - Time-to-live for frame:
   - `forever` - Never expire
-  - `ephemeral` - Remove after reading
+  - `ephemeral` - Not stored; only active subscribers receive it
   - `time:<ms>` - Expire after duration
   - `head:<n>` - Keep only N most recent frames
 


### PR DESCRIPTION
## Summary
- align TTL docs with implementation: ephemeral events are not stored
- document generator output streaming binary chunks

## Testing
- `npm run build`