### PR TITLE
fix(generator): skip restart after terminate

### DIFF
--- a/src/generators/serve.rs
+++ b/src/generators/serve.rs
@@ -79,6 +79,8 @@ pub async fn serve(
             {
                 compacted.insert((prefix.to_string(), frame.context_id), frame);
             }
+        } else if let Some(prefix) = frame.topic.strip_suffix(".terminate") {
+            compacted.remove(&(prefix.to_string(), frame.context_id));
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid respawning generators that were terminated before the startup threshold

## Testing
- `./scripts/check.sh`