### PR TITLE
docs: add brew service start step

### DIFF
--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -20,6 +20,7 @@ cargo install cross-stream --locked
 <TabItem label="brew">
 ```sh
 brew install cablehead/tap/cross-stream
+brew services start cablehead/tap/cross-stream  # starts a store in ~/.local/share/cross.stream/store
 ```
 </TabItem>
 


### PR DESCRIPTION
## Summary
- mention `brew services start` in installation guide

## Testing
- `cd ./docs && npm run build`