### PR TITLE
feat(generator): refactor runtime and protocol

### DIFF
--- a/docs/src/content/docs/reference/generators.mdx
+++ b/docs/src/content/docs/reference/generators.mdx
@@ -40,7 +40,7 @@ Generators emit lifecycle events to track their state:
 | `<topic>.start`       | Generator has started processing        |
 | `<topic>.recv`        | Output value from the generator         |
 | `<topic>.stop` | Generator pipeline has stopped. The \`meta.reason\` field is a string enum with values `finished`, `error`, `terminate` and `update`. When `finished` or `error`, the pipeline will be restarted automatically; `terminate` means it was stopped manually and the generator loop for this topic/context will shut down. `update` indicates the generator reloaded due to a new `.spawn` frame. |
-| `<topic>.spawn.error` | Error occurred while spawning generator |
+| `<topic>.parse.error` | Script failed to parse |
 
 All events include `source_id` which is the ID of the generator instance. When a `.stop` frame has `meta.reason` set to `update`, it also includes `update_id` referencing the spawn that triggered the reload.
 
@@ -77,14 +77,13 @@ When running this generator:
 
 ## Error Handling
 
-If a generator encounters an error during spawning a `<topic>.spawn.error` frame
+If a generator encounters an error during spawning a `<topic>.parse.error` frame
 is emitted with:
 
 - `source_id`: ID of the failed spawn attempt
 - `reason`: Error message describing what went wrong
 
-The generator also appends a `<topic>.stop` frame with `meta.reason` set to
-`spawn.error` so the failed instance can be cleaned up.
+The generator does not start and no stop frame is produced.
 
 ## Stopping Generators
 
@@ -94,5 +93,5 @@ The generator will stop and emit a `<topic>.stop` frame with `meta.reason` set t
 
 Appending a new `<topic>.spawn` frame while a generator of the same topic and
 context is running reloads it with the new script. If the reload fails to parse,
-you'll see a `<topic>.spawn.error` frame, and the previous generator continues
+you'll see a `<topic>.parse.error` frame, and the previous generator continues
 running.

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -1,7 +1,10 @@
 mod generator;
 mod serve;
 
-pub use generator::{spawn as spawn_generator_loop, GeneratorLoop, GeneratorScriptOptions};
+pub use generator::{
+    spawn as spawn_generator_loop, GeneratorEventKind, GeneratorLoop, GeneratorScriptOptions,
+    StopReason, Task,
+};
 
 #[cfg(test)]
 mod tests;

--- a/src/generators/serve.rs
+++ b/src/generators/serve.rs
@@ -24,7 +24,7 @@ async fn try_start_task(
         });
 
         if let Err(e) = store.append(
-            Frame::builder(format!("{}.spawn.error", topic), frame.context_id)
+            Frame::builder(format!("{}.parse.error", topic), frame.context_id)
                 .meta(meta)
                 .build(),
         ) {
@@ -71,10 +71,10 @@ pub async fn serve(
         if frame.topic == "xs.threshold" {
             break;
         }
-        if frame.topic.ends_with(".spawn") || frame.topic.ends_with(".spawn.error") {
+        if frame.topic.ends_with(".spawn") || frame.topic.ends_with(".parse.error") {
             if let Some(prefix) = frame
                 .topic
-                .strip_suffix(".spawn.error")
+                .strip_suffix(".parse.error")
                 .or_else(|| frame.topic.strip_suffix(".spawn"))
             {
                 compacted.insert((prefix.to_string(), frame.context_id), frame);
@@ -96,8 +96,8 @@ pub async fn serve(
             continue;
         }
 
-        if let Some(_prefix) = frame.topic.strip_suffix(".spawn.error") {
-            // spawn.error frames are informational; ignore them
+        if let Some(_prefix) = frame.topic.strip_suffix(".parse.error") {
+            // parse.error frames are informational; ignore them
             continue;
         }
 
@@ -108,7 +108,7 @@ pub async fn serve(
                 .and_then(|m| m.get("reason"))
                 .and_then(|v| v.as_str())
             {
-                if reason == "terminate" || reason == "spawn.error" {
+                if reason == "terminate" || reason == "error" {
                     let key = (prefix.to_string(), frame.context_id);
                     active.remove(&key);
                 }


### PR DESCRIPTION
## Summary
- update generator runtime with Task struct and typed events
- emit parse errors instead of spawn errors
- adjust ServeLoop and docs for new protocol
- add unit test for emit_event helper

## Testing
- `./scripts/check.sh`
- `cd docs && npm run build`