### PR TITLE
feat(generator): add shutdown lifecycle event

### DIFF
--- a/docs/src/content/docs/reference/generators.mdx
+++ b/docs/src/content/docs/reference/generators.mdx
@@ -41,8 +41,9 @@ Generators emit lifecycle events to track their state:
 | `<topic>.recv`        | Output value from the generator         |
 | `<topic>.stop` | Generator pipeline has stopped. The \`meta.reason\` field is a string enum with values `finished`, `error`, `terminate` and `update`. When `finished` or `error`, the pipeline will be restarted automatically; `terminate` means it was stopped manually and the generator loop for this topic/context will shut down. `update` indicates the generator reloaded due to a new `.spawn` frame. |
 | `<topic>.parse.error` | Script failed to parse |
+| `<topic>.shutdown` | Generator loop has fully exited; ServeLoop evicts it |
 
-All events include `source_id` which is the ID of the generator instance. When a `.stop` frame has `meta.reason` set to `update`, it also includes `update_id` referencing the spawn that triggered the reload.
+All events include `source_id` which is the ID of the generator instance. When a `.stop` frame has `meta.reason` set to `update`, it also includes `update_id` referencing the spawn that triggered the reload. ServeLoop evicts a generator when it receives a `<topic>.shutdown` frame.
 
 ## Configuration Options
 

--- a/src/generators/serve.rs
+++ b/src/generators/serve.rs
@@ -101,18 +101,8 @@ pub async fn serve(
             continue;
         }
 
-        if let Some(prefix) = frame.topic.strip_suffix(".stop") {
-            if let Some(reason) = frame
-                .meta
-                .as_ref()
-                .and_then(|m| m.get("reason"))
-                .and_then(|v| v.as_str())
-            {
-                if reason == "terminate" || reason == "error" {
-                    let key = (prefix.to_string(), frame.context_id);
-                    active.remove(&key);
-                }
-            }
+        if let Some(prefix) = frame.topic.strip_suffix(".shutdown") {
+            active.remove(&(prefix.to_string(), frame.context_id));
             continue;
         }
     }


### PR DESCRIPTION
## Summary
- emit shutdown event when the generator loop fully exits
- have ServeLoop evict generators based on `.shutdown`
- update generator docs with shutdown lifecycle event
- expect shutdown frames in tests

## Testing
- `./scripts/check.sh`
- `cd docs && npm run build`