### PR TITLE
feat(cat): add topic filtering

### DIFF
--- a/docs/src/content/docs/getting-started/first-stream.mdx
+++ b/docs/src/content/docs/getting-started/first-stream.mdx
@@ -224,14 +224,13 @@ Finally, let's pull a list of all our notes.
 
 <TabItem label="nushell">
 
-We can use `where` to filter the stream for only the `notes` topic, and then use
-the `each` command to pull out the content of each note:
+We can filter directly by topic using `--topic` and then use the `each` command to pull out the content of each note:
 
 ```nushell withOutput
-> .cat | where topic == "notes" | each {.cas}
+> .cat --topic notes | each {.cas}
 ───┬───────────────────
- 0 │ a quick note
- 1 │ submit TPS report
+0 │ a quick note
+1 │ submit TPS report
 ───┴───────────────────
 ```
 
@@ -242,7 +241,7 @@ Fun! 🎉
 <TabItem label="bash">
 
 ```bash withOutput
-> xs cat ./store | jq -r 'select(.topic == "notes") | .hash' | xargs -I{} xs cas ./store {}
+> xs cat ./store --topic notes | jq -r .hash | xargs -I{} xs cas ./store {}
 a quick note
 submit TPS report
 ```

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -64,6 +64,7 @@ xs cat <addr> [options]
 | `--sse` | Use Server-Sent Events format |
 | `--context <id>`, `-c <id>` | Context ID (defaults to system context) |
 | `--all`, `-a` | Retrieve frames across all contexts |
+| `--topic <topic>`, `-T <topic>` | Filter frames by topic |
 
 Example:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,10 @@ struct CommandCat {
     /// Retrieve all frames, across contexts
     #[clap(long, short = 'a')]
     all: bool,
+
+    /// Filter by topic
+    #[clap(long = "topic", short = 'T')]
+    topic: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -272,6 +276,7 @@ async fn cat(args: CommandCat) -> Result<(), Box<dyn std::error::Error + Send + 
         .maybe_last_id(last_id)
         .maybe_limit(args.limit.map(|l| l as usize))
         .maybe_context_id(context_id)
+        .maybe_topic(args.topic.clone())
         .build();
     let mut receiver = xs::client::cat(&args.addr, options, args.sse).await?;
     let mut stdout = tokio::io::stdout();

--- a/xs.nu
+++ b/xs.nu
@@ -71,6 +71,7 @@ def _cat [options: record] {
     (if $options.limit? != null { ["--limit" $options.limit] })
     (if $options.pulse? != null { ["--pulse" $options.pulse] })
     (if $options.context? != null { ["--context" $options.context] })
+    (if $options.topic? != null { ["--topic" $options.topic] })
   ] | compact | flatten
 
   xs cat (xs-addr) ...$params | lines | each {|x| $x | from json }
@@ -85,6 +86,7 @@ export def .cat [
   --limit: int
   --context (-c): string # the context to read from
   --all (-a) # cat across all contexts
+  --topic (-T): string # filter by topic
 ] {
   _cat {
     follow: $follow
@@ -94,6 +96,7 @@ export def .cat [
     limit: $limit
     context: (if not $all { (xs-context $context (metadata $context).span) })
     all: $all
+    topic: $topic
   } | conditional-pipe (not ($detail or $all)) { each { reject context_id ttl } }
 }
 


### PR DESCRIPTION
## Summary
- support specifying a topic when reading streams
- add `--topic` CLI flag and nushell wrapper option
- implement topic filtering in the store using the topic index
- document new option and update tutorial examples
- test topic filtering

## Testing
- `./scripts/check.sh`
- `cd docs && npm run build`
