### PR TITLE
fix(nu): remove config dir from autoload candidates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -580,14 +580,6 @@ fn find_paths() -> Result<(PathBuf, PathBuf), String> {
 
     let auto_candidates: Vec<PathBuf> = {
         let mut v = Vec::new();
-        if let Some(conf) = config_dir() {
-            v.push(
-                conf.join("nushell")
-                    .join("vendor")
-                    .join("autoload")
-                    .join("xs-use.nu"),
-            );
-        }
         for dir in nu_vendor_autoload_dirs() {
             v.push(dir.join("xs-use.nu"));
         }


### PR DESCRIPTION
## Summary
- avoid pushing the config dir into autoload candidates

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841d2d6a814832c8cc8ef6829aaaf8e