### PR TITLE
docs: clarify deno usage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,54 +1,55 @@
-# Starlight Starter Kit: Basics
+# xs Documentation
 
-[![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
+This folder contains the [Starlight](https://starlight.astro.build/) site that powers the
+project documentation. It is built with [Astro](https://astro.build/) and uses
+Deno for development and building.
 
-```
-npm create astro@latest -- --template starlight
-```
+## Requirements
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/starlight/tree/main/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/starlight/tree/main/examples/basics)
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/withastro/starlight&create_from_path=examples/basics)
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwithastro%2Fstarlight%2Ftree%2Fmain%2Fexamples%2Fbasics&project-name=my-starlight-docs&repository-name=my-starlight-docs)
+- [Deno](https://deno.com/runtime) 1.38 or newer
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+Deno can run the Astro CLI directly from npm without installing a local
+`node_modules` directory.
 
-## 🚀 Project Structure
+## Development
 
-Inside of your Astro + Starlight project, you'll see the following folders and files:
+Start a local server from the `docs` directory:
 
-```
-.
-├── public/
-├── src/
-│   ├── assets/
-│   ├── content/
-│   │   ├── docs/
-│   └── content.config.ts
-├── astro.config.mjs
-├── package.json
-└── tsconfig.json
+```sh
+deno run -A npm:astro dev
 ```
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
+The site will be available at `http://localhost:4321`.
 
-Images can be added to `src/assets/` and embedded in Markdown with a relative link.
+## Building
 
-Static assets, like favicons, can be placed in the `public/` directory.
+Generate the static site:
 
-## 🧞 Commands
+```sh
+deno run -A npm:astro build
+```
 
-All commands are run from the root of the project, from a terminal:
+Preview the result with:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+```sh
+deno run -A npm:astro preview
+```
 
-## 👀 Want to learn more?
+All generated files will be placed in `docs/dist/`.
 
-Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).
+## Project layout
+
+```
+docs/
+  public/        # static files copied as-is
+  src/
+    assets/      # images and other assets
+    content/     # documentation pages
+    content.config.ts
+  astro.config.mjs
+  package.json
+  tsconfig.json
+```
+
+For more details on customizing Starlight, see the
+[official Starlight documentation](https://starlight.astro.build/).


### PR DESCRIPTION
## Summary
- update docs/README to remove Node instructions and clarify Deno-only development

## Testing
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fa6f84824832cb548ba7d08d45215