### PR TITLE
feat: add optional topic and -n flag to .last

### DIFF
--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -22,7 +22,7 @@ xs <COMMAND> [OPTIONS]
 - `cas` – Retrieve content from Content-Addressable Storage
 - `cas-post` – Store content in Content-Addressable Storage
 - `remove` – Remove an item from the stream
-- `last` – Get the most recent frame for a topic
+- `last` – Get the most recent frame(s), optionally filtered by topic
 - `get` – Get a frame by ID
 - `import` – Import a frame directly into the store
 - `eval` – Evaluate a Nushell script with store helper commands available
@@ -160,17 +160,27 @@ xs remove <addr> <id>
 
 ### `last`
 
-Get the most recent frame for a topic.
+Get the most recent frame(s), optionally filtered by topic.
 
 ```sh
-xs last <addr> <topic> [--follow]
+xs last <addr> [topic] [-n count] [--follow]
 ```
 
-| Option           | Description             |
-| ---------------- | ----------------------- |
-| `<addr>`         | Address to connect to   |
-| `<topic>`        | Topic to inspect        |
-| `--follow`, `-f` | Follow for updates      |
+| Option           | Description                                      |
+| ---------------- | ------------------------------------------------ |
+| `<addr>`         | Address to connect to                            |
+| `[topic]`        | Topic to query (optional, supports wildcards)    |
+| `-n`, `--last`   | Number of frames to return (default: 1)          |
+| `--follow`, `-f` | Follow for updates                               |
+
+Examples:
+```sh
+xs last ./store note           # last frame for topic "note"
+xs last ./store                # last frame across all topics
+xs last ./store note -n 5      # last 5 frames for topic "note"
+xs last ./store -n 10          # last 10 frames across all topics
+xs last ./store "user.*"       # last frame matching wildcard
+```
 
 ### `get`
 

--- a/docs/src/content/docs/reference/commands.mdx
+++ b/docs/src/content/docs/reference/commands.mdx
@@ -119,7 +119,7 @@ cross.stream:
 - `.append` – append a new frame. Metadata you provide is merged with
   `command_id` and `frame_id`.
 - `.cat` – read frames from the store.
-- `.last` – fetch the most recent frame for a topic.
+- `.last` – fetch the most recent frame(s), optionally filtered by topic.
 - `.cas` – read content from CAS by hash.
 - `.get` – retrieve a frame by ID.
 - `.remove` – delete a frame from the stream.

--- a/docs/src/content/docs/reference/store-api.mdx
+++ b/docs/src/content/docs/reference/store-api.mdx
@@ -84,19 +84,22 @@ curl --unix-socket ./store/sock -X DELETE \
 
 Response: 204 on success
 
-### `GET /last/{topic}`
+### `GET /last[/{topic}]`
 
-Get most recent frame for topic
+Get most recent frame(s), optionally filtered by topic.
 
 ```sh
 curl --unix-socket ./store/sock http://localhost/last/topic
+curl --unix-socket ./store/sock http://localhost/last
+curl --unix-socket ./store/sock "http://localhost/last/topic?last=5"
 ```
 
 Query Parameters:
 
-- `follow` - Long poll for new frames on this topic
+- `last` - Number of frames to return (default: 1). Returns NDJSON when > 1.
+- `follow` - Long poll for new frames
 
-Response: Most recent frame for topic or 404 if not found
+Response: Most recent frame(s) as JSON (single) or NDJSON (multiple/follow), or 404 if not found
 
 ### `POST /cas`
 

--- a/docs/src/content/docs/reference/xs-nu.mdx
+++ b/docs/src/content/docs/reference/xs-nu.mdx
@@ -61,15 +61,23 @@ Stream frames from the store. Wraps [`xs cat`](../cli/#cat).
 
 ### `.last`
 
-Get the most recent frame for a topic. Wraps [`xs last`](../cli/#last).
+Get the most recent frame(s) for a topic. Wraps [`xs last`](../cli/#last).
 
 ```nushell
-.last <topic> [--follow]
+.last [topic] [-n count] [--follow]
 ```
 
+- `topic` - Topic to query (optional, defaults to all topics). Supports wildcards like `user.*`.
+- `-n` - Number of frames to return (default: 1)
+- `--follow` / `-f` - Stream updates as they arrive
+
 ```nushell
-.last note
-let latest_note = .last note
+.last note              # last frame for topic "note"
+.last                   # last frame across all topics
+.last note -n 5         # last 5 frames for topic "note"
+.last -n 10             # last 10 frames across all topics
+.last "user.*"          # last frame matching wildcard
+.last note --follow     # stream updates for topic "note"
 ```
 
 ### `.remove`

--- a/src/api.rs
+++ b/src/api.rs
@@ -494,7 +494,7 @@ async fn handle_last_get(
             .maybe_topic(topic.map(|t| t.to_string()))
             .build();
 
-        let frames: Vec<Frame> = store.read_sync_with_options(options).collect();
+        let frames: Vec<Frame> = store.read_sync(options).collect();
 
         if frames.is_empty() {
             return response_404();

--- a/src/generators/tests.rs
+++ b/src/generators/tests.rs
@@ -626,8 +626,8 @@ fn test_emit_event_helper() {
     )
     .unwrap();
     assert!(matches!(ev.kind, GeneratorEventKind::Recv { .. }));
-    let frame = store.last("helper.data").unwrap();
-    let bytes = store.cas_read_sync(&frame.hash.unwrap());
+    assert_eq!(ev.frame.topic, "helper.data");
+    let bytes = store.cas_read_sync(&ev.frame.hash.unwrap());
     assert_eq!(bytes.unwrap(), b"hi".to_vec());
 
     let ev = emit_event(
@@ -640,7 +640,7 @@ fn test_emit_event_helper() {
     .unwrap();
     assert!(matches!(ev.kind, GeneratorEventKind::Stopped(_)));
 
-    let _ = emit_event(
+    let ev = emit_event(
         &store,
         &loop_ctx,
         task.id,
@@ -648,7 +648,7 @@ fn test_emit_event_helper() {
         GeneratorEventKind::Shutdown,
     )
     .unwrap();
-    assert!(store.last("helper.shutdown").is_some());
+    assert_eq!(ev.frame.topic, "helper.shutdown");
 }
 
 #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,11 @@ struct CommandLast {
 
     /// Topic to get the most recent frame for (supports wildcards like user.*)
     #[clap(value_parser = parse_topic_query)]
-    topic: String,
+    topic: Option<String>,
+
+    /// Number of frames to return
+    #[clap(long, short = 'n', default_value = "1")]
+    last: usize,
 
     /// Follow for updates to the most recent frame
     #[clap(long, short = 'f')]
@@ -514,7 +518,7 @@ async fn remove(args: CommandRemove) -> Result<(), Box<dyn std::error::Error + S
 }
 
 async fn last(args: CommandLast) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    xs::client::last(&args.addr, &args.topic, args.follow).await
+    xs::client::last(&args.addr, args.topic.as_deref(), args.last, args.follow).await
 }
 
 async fn get(args: CommandGet) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/src/nu/commands/cat_command.rs
+++ b/src/nu/commands/cat_command.rs
@@ -92,7 +92,7 @@ impl Command for CatCommand {
             .maybe_topic(topic)
             .build();
 
-        let frames: Vec<_> = self.store.read_sync_with_options(options).collect();
+        let frames: Vec<_> = self.store.read_sync(options).collect();
 
         use nu_protocol::Value;
 

--- a/src/nu/commands/last_command.rs
+++ b/src/nu/commands/last_command.rs
@@ -60,7 +60,7 @@ impl Command for LastCommand {
 
         let frames: Vec<Value> = self
             .store
-            .read_sync_with_options(options)
+            .read_sync(options)
             .map(|frame| util::frame_to_value(&frame, span))
             .collect();
 

--- a/src/nu/commands/last_stream_command.rs
+++ b/src/nu/commands/last_stream_command.rs
@@ -6,7 +6,7 @@ use nu_protocol::{
 use std::time::Duration;
 
 use crate::nu::util;
-use crate::store::{FollowOption, ReadOptions, Store, TTL};
+use crate::store::{FollowOption, ReadOptions, Store};
 
 #[derive(Clone)]
 pub struct LastStreamCommand {
@@ -107,11 +107,6 @@ impl Command for LastStreamCommand {
                 let mut receiver = store.read(options).await;
 
                 while let Some(frame) = receiver.recv().await {
-                    // Skip ephemeral frames (xs.threshold, xs.pulse)
-                    if frame.ttl == Some(TTL::Ephemeral) {
-                        continue;
-                    }
-
                     let value = util::frame_to_value(&frame, span);
 
                     if tx.send(value).is_err() {

--- a/src/nu/commands/last_stream_command.rs
+++ b/src/nu/commands/last_stream_command.rs
@@ -71,7 +71,7 @@ impl Command for LastStreamCommand {
 
             let frames: Vec<Value> = self
                 .store
-                .read_sync_with_options(options)
+                .read_sync(options)
                 .map(|frame| util::frame_to_value(&frame, span))
                 .collect();
 

--- a/src/nu/commands/last_stream_command.rs
+++ b/src/nu/commands/last_stream_command.rs
@@ -1,11 +1,12 @@
 use nu_engine::CallExt;
 use nu_protocol::engine::{Call, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, ListStream, PipelineData, ShellError, Signals, Signature, SyntaxShape, Type,
+    Category, ListStream, PipelineData, ShellError, Signals, Signature, SyntaxShape, Type, Value,
 };
 use std::time::Duration;
 
-use crate::store::{FollowOption, ReadOptions, Store};
+use crate::nu::util;
+use crate::store::{FollowOption, ReadOptions, Store, TTL};
 
 #[derive(Clone)]
 pub struct LastStreamCommand {
@@ -26,10 +27,16 @@ impl Command for LastStreamCommand {
     fn signature(&self) -> Signature {
         Signature::build(".last")
             .input_output_types(vec![(Type::Nothing, Type::Any)])
-            .required(
+            .optional(
                 "topic",
                 SyntaxShape::String,
-                "topic to get most recent frame from",
+                "topic to get most recent frame from (default: all topics)",
+            )
+            .named(
+                "last",
+                SyntaxShape::Int,
+                "number of frames to return",
+                Some('n'),
             )
             .switch(
                 "follow",
@@ -40,7 +47,7 @@ impl Command for LastStreamCommand {
     }
 
     fn description(&self) -> &str {
-        "get the most recent frame for a topic"
+        "get the most recent frame(s) for a topic"
     }
 
     fn run(
@@ -50,42 +57,48 @@ impl Command for LastStreamCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let topic: String = call.req(engine_state, stack, 0)?;
+        let topic: Option<String> = call.opt(engine_state, stack, 0)?;
+        let n: usize = call
+            .get_flag::<i64>(engine_state, stack, "last")?
+            .map(|v| v as usize)
+            .unwrap_or(1);
         let follow = call.has_flag(engine_state, stack, "follow")?;
-
         let span = call.head;
-        let current_head = self.store.last(&topic);
 
         if !follow {
-            // Non-follow mode: just return current head or empty
-            return if let Some(frame) = current_head {
+            // Non-follow mode: use sync path
+            let options = ReadOptions::builder().last(n).maybe_topic(topic).build();
+
+            let frames: Vec<Value> = self
+                .store
+                .read_sync_with_options(options)
+                .map(|frame| util::frame_to_value(&frame, span))
+                .collect();
+
+            return if frames.is_empty() {
+                Ok(PipelineData::Empty)
+            } else if frames.len() == 1 {
                 Ok(PipelineData::Value(
-                    crate::nu::util::frame_to_value(&frame, span),
+                    frames.into_iter().next().unwrap(),
                     None,
                 ))
             } else {
-                Ok(PipelineData::Empty)
+                Ok(PipelineData::Value(Value::list(frames, span), None))
             };
         }
 
-        // Follow mode: stream head updates
+        // Follow mode: use async path with streaming
         let options = ReadOptions::builder()
+            .last(n)
+            .maybe_topic(topic)
             .follow(FollowOption::On)
-            .maybe_after(current_head.as_ref().map(|f| f.id))
             .build();
 
         let store = self.store.clone();
         let signals = engine_state.signals().clone();
-        let topic_filter = topic.clone();
 
         // Create channel for async -> sync bridge
         let (tx, rx) = std::sync::mpsc::channel();
-
-        // If there's a current head, send it first
-        if let Some(frame) = current_head {
-            let value = crate::nu::util::frame_to_value(&frame, span);
-            let _ = tx.send(value);
-        }
 
         // Spawn thread to handle async store.read()
         std::thread::spawn(move || {
@@ -94,12 +107,12 @@ impl Command for LastStreamCommand {
                 let mut receiver = store.read(options).await;
 
                 while let Some(frame) = receiver.recv().await {
-                    // Filter for matching topic
-                    if frame.topic != topic_filter {
+                    // Skip ephemeral frames (xs.threshold, xs.pulse)
+                    if frame.ttl == Some(TTL::Ephemeral) {
                         continue;
                     }
 
-                    let value = crate::nu::util::frame_to_value(&frame, span);
+                    let value = util::frame_to_value(&frame, span);
 
                     if tx.send(value).is_err() {
                         break;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -441,27 +441,8 @@ impl Store {
         rx
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn read_sync(
-        &self,
-        after: Option<&Scru128Id>,
-        limit: Option<usize>,
-    ) -> impl Iterator<Item = Frame> + '_ {
-        self.iter_frames(after.map(|id| (id, false)))
-            .filter(move |frame| {
-                if let Some(TTL::Time(ttl)) = frame.ttl.as_ref() {
-                    if is_expired(&frame.id, ttl) {
-                        let _ = self.gc_tx.send(GCTask::Remove(frame.id));
-                        return false;
-                    }
-                }
-                true
-            })
-            .take(limit.unwrap_or(usize::MAX))
-    }
-
     /// Read frames synchronously with full ReadOptions support.
-    pub fn read_sync_with_options(&self, options: ReadOptions) -> impl Iterator<Item = Frame> + '_ {
+    pub fn read_sync(&self, options: ReadOptions) -> impl Iterator<Item = Frame> + '_ {
         let gc_tx = self.gc_tx.clone();
 
         // Filter out expired frames

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -513,31 +513,6 @@ impl Store {
             .map(|value| deserialize_frame((id.as_bytes(), value)))
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn last(&self, topic: &str) -> Option<Frame> {
-        if topic == "*" {
-            // All topics: scan all frames and find the one with the highest ID
-            self.idx_topic.iter().rev().find_map(|guard| {
-                let key = guard.key().ok()?;
-                self.get(&idx_topic_frame_id_from_key(&key))
-            })
-        } else if let Some(prefix) = topic.strip_suffix(".*") {
-            // Wildcard: find last frame matching prefix
-            let prefix_with_dot = format!("{}.", prefix);
-            self.iter_frames_by_topic_prefix(&prefix_with_dot, None)
-                .max_by_key(|f| f.id)
-        } else {
-            // Exact topic match
-            self.idx_topic
-                .prefix(idx_topic_key_prefix(topic))
-                .rev()
-                .find_map(|guard| {
-                    let key = guard.key().ok()?;
-                    self.get(&idx_topic_frame_id_from_key(&key))
-                })
-        }
-    }
-
     #[tracing::instrument(skip(self), fields(id = %id.to_string()))]
     pub fn remove(&self, id: &Scru128Id) -> Result<(), crate::error::Error> {
         let Some(frame) = self.get(id) else {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -622,6 +622,19 @@ async fn test_eval_last_follow() {
         "First frame from .last --follow should be the current last"
     );
 
+    // Should receive xs.threshold marker after historical frames
+    line.clear();
+    let result = tokio::time::timeout(Duration::from_secs(2), reader.read_line(&mut line))
+        .await
+        .expect("Timeout waiting for xs.threshold")
+        .expect("Failed to read xs.threshold");
+    assert!(result > 0, "Should receive xs.threshold");
+    let threshold_frame: serde_json::Value = serde_json::from_str(&line.trim()).unwrap();
+    assert_eq!(
+        threshold_frame["topic"], "xs.threshold",
+        "Should receive xs.threshold marker after historical frames"
+    );
+
     // Append new frame while following
     cmd!(
         assert_cmd::cargo::cargo_bin!("xs"),

--- a/xs.nu
+++ b/xs.nu
@@ -86,13 +86,20 @@ export def .get [id: string] {
 }
 
 export def .last [
-  topic: string
+  topic?: string
+  --last (-n): int  # Number of frames to return
   --follow (-f)
 ] {
-  if $follow {
-    xs last (xs-addr) $topic --follow | lines | each {|x| $x | from json }
+  let args = [
+    (if $topic != null { [$topic] })
+    (if $last != null { ["-n" $last] })
+    (if $follow { ["--follow"] })
+  ] | compact | flatten
+
+  if $follow or ($last != null and $last > 1) {
+    xs last (xs-addr) ...$args | lines | each {|x| $x | from json }
   } else {
-    xs last (xs-addr) $topic | from json
+    xs last (xs-addr) ...$args | from json
   }
 }
 


### PR DESCRIPTION
## Summary

- `.last` now accepts optional topic (defaults to all topics) and `-n` flag for multiple frames
- Consistent across all interfaces: nushell commands, HTTP API, CLI, xs.nu wrapper
- Consolidates on `ReadOptions` / `read_sync()` as the unified query interface
- Removes redundant `store.last()` method

## Changes

- **Nushell commands**: `LastCommand` and `LastStreamCommand` updated with optional topic and `-n` flag
- **HTTP API**: `/last[/{topic}]` with `?last=N` query param
- **CLI**: `xs last <addr> [topic] [-n count] [--follow]`
- **xs.nu**: `.last [topic] [-n count] [--follow]`
- **Store cleanup**: Removed `store.last()`, renamed `read_sync_with_options` to `read_sync`
- **xs.threshold**: Now emitted correctly in follow mode for all interfaces

## Test plan

- [x] Unit tests for `.last` command variants
- [x] Integration test `test_xs_last_cli` covering all flag combinations
- [x] All existing tests pass
- [x] Documentation updated