### PR TITLE
refactor!: unified dispatcher with VFS module system

### DIFF
--- a/docs/src/content/docs/reference/commands.mdx
+++ b/docs/src/content/docs/reference/commands.mdx
@@ -1,6 +1,6 @@
 ---
 title: Commands
-description: Stateless, parallelizable operations that can be called on-demand with streaming results
+description: Stateless, parallelizable operations that can be called on-demand
 sidebar:
   order: 4
 ---
@@ -120,7 +120,7 @@ cross.stream:
 | -------------- | ----------------------- | ---------------------- | --------------- |
 | State          | Stateless               | Stateful between calls | Stateless       |
 | Execution      | On-demand               | Event-driven           | Continuous      |
-| Results        | Streamed immediately    | Batched on completion  | Streamed        |
+| Results        | Collected into response | Batched on completion  | Streamed        |
 | Parallelism    | Multiple parallel calls | Sequential processing  | Single instance |
 | Error Handling | Per-invocation          | Unregisters handler    | Auto-restarts   |
 | Modules        | Supported               | Supported              | Supported       |

--- a/docs/src/content/docs/reference/commands.mdx
+++ b/docs/src/content/docs/reference/commands.mdx
@@ -90,7 +90,7 @@ invocation is independent.
 
 ## Modules
 
-Commands can use modules registered via `nu.*` topics. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
+Commands can use modules registered via `*.nu` topics. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
 
 ```nushell
 r#'{

--- a/docs/src/content/docs/reference/commands.mdx
+++ b/docs/src/content/docs/reference/commands.mdx
@@ -29,11 +29,6 @@ r#'{
     1..($n) | each {$"($in): ($input)"}
   }
 
-  # Optional: Module definitions
-  modules: {
-    "my-util": "export def format [x] { $\"formatted: ($x)\" }"
-  }
-
   # Optional: Control output frame behavior
   return_options: {
     suffix: ".output" # Output topic suffix (default: ".response")
@@ -95,25 +90,7 @@ invocation is independent.
 
 ## Modules
 
-### Inline Modules
-
-Commands can define custom Nushell modules inline:
-
-```nushell
-r#'{
-  run: {|frame|
-    my-math double ($frame.meta.args.number)
-  }
-
-  modules: {
-    "my-math": "export def double [x] { $x * 2 }"
-  }
-}'# | .append calculator.define
-```
-
-### VFS Modules
-
-Commands can also use modules registered via `nu.*` topics. These are shared across all components and pinned by SCRU128 ID. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
+Commands can use modules registered via `nu.*` topics. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
 
 ```nushell
 r#'{
@@ -146,5 +123,4 @@ cross.stream:
 | Results        | Streamed immediately    | Batched on completion  | Streamed        |
 | Parallelism    | Multiple parallel calls | Sequential processing  | Single instance |
 | Error Handling | Per-invocation          | Unregisters handler    | Auto-restarts   |
-| Inline Modules | Supported               | Supported              | Not supported   |
-| VFS Modules    | Supported               | Supported              | Supported       |
+| Modules        | Supported               | Supported              | Supported       |

--- a/docs/src/content/docs/reference/commands.mdx
+++ b/docs/src/content/docs/reference/commands.mdx
@@ -95,7 +95,7 @@ Commands can use modules registered via `*.nu` topics. See <Link to="/reference/
 ```nushell
 r#'{
   run: {|frame|
-    use xs/01JAR5EXAMPLE/my-math
+    use xs/my-math
     my-math double ($frame.meta.args.number)
   }
 }'# | .append calculator.define

--- a/docs/src/content/docs/reference/commands.mdx
+++ b/docs/src/content/docs/reference/commands.mdx
@@ -95,7 +95,9 @@ invocation is independent.
 
 ## Modules
 
-Commands can use custom Nushell modules:
+### Inline Modules
+
+Commands can define custom Nushell modules inline:
 
 ```nushell
 r#'{
@@ -109,7 +111,18 @@ r#'{
 }'# | .append calculator.define
 ```
 
-This allows you to modularize your commands and reuse code across different commands.
+### VFS Modules
+
+Commands can also use modules registered via `nu.*` topics. These are shared across all components and pinned by SCRU128 ID. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
+
+```nushell
+r#'{
+  run: {|frame|
+    use xs/01JAR5EXAMPLE/my-math
+    my-math double ($frame.meta.args.number)
+  }
+}'# | .append calculator.define
+```
 
 ## Built-in Store Commands
 
@@ -133,4 +146,5 @@ cross.stream:
 | Results        | Streamed immediately    | Batched on completion  | Streamed        |
 | Parallelism    | Multiple parallel calls | Sequential processing  | Single instance |
 | Error Handling | Per-invocation          | Unregisters handler    | Auto-restarts   |
-| Modules        | Supported               | Supported              | Not supported   |
+| Inline Modules | Supported               | Supported              | Not supported   |
+| VFS Modules    | Supported               | Supported              | Supported       |

--- a/docs/src/content/docs/reference/generators.mdx
+++ b/docs/src/content/docs/reference/generators.mdx
@@ -85,7 +85,7 @@ This generator will emit frames with the topic `logs.line` and automatically mai
 
 ## Modules
 
-Generators can use modules registered via `nu.*` topics. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
+Generators can use modules registered via `*.nu` topics. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
 
 ```nushell
 r#'{

--- a/docs/src/content/docs/reference/generators.mdx
+++ b/docs/src/content/docs/reference/generators.mdx
@@ -90,7 +90,7 @@ Generators can use modules registered via `*.nu` topics. See <Link to="/referenc
 ```nushell
 r#'{
   run: {||
-    use xs/01JAR5EXAMPLE/my-parser
+    use xs/my-parser
     ^tail -F data.log | lines | each {|line| my-parser parse $line }
   }
 }'# | .append log.spawn

--- a/docs/src/content/docs/reference/generators.mdx
+++ b/docs/src/content/docs/reference/generators.mdx
@@ -40,9 +40,9 @@ Generators emit lifecycle events to track their state. See <Link to="/reference/
 | `<topic>.recv`        | Output value from the generator         |
 | `<topic>.stopped` | Generator pipeline has stopped. The \`meta.reason\` field is a string enum with values `finished`, `error`, `terminate` and `update`. When `finished` or `error`, the pipeline will be restarted automatically; `terminate` means it was stopped manually and the generator loop will shut down. `update` indicates the generator reloaded due to a new `.spawn` frame. |
 | `<topic>.parse.error` | Script failed to parse |
-| `<topic>.shutdown` | Generator loop has fully exited; ServeLoop evicts it |
+| `<topic>.shutdown` | Generator loop has fully exited; the dispatcher evicts it |
 
-All events include `source_id` which is the ID of the generator instance. When a `.stopped` frame has `meta.reason` set to `update`, it also includes `update_id` referencing the spawn that triggered the reload. ServeLoop evicts a generator when it receives a `<topic>.shutdown` frame.
+All events include `source_id` which is the ID of the generator instance. When a `.stopped` frame has `meta.reason` set to `update`, it also includes `update_id` referencing the spawn that triggered the reload. The dispatcher evicts a generator when it receives a `<topic>.shutdown` frame.
 
 ## Configuration Options
 

--- a/docs/src/content/docs/reference/generators.mdx
+++ b/docs/src/content/docs/reference/generators.mdx
@@ -83,9 +83,9 @@ r#'{
 
 This generator will emit frames with the topic `logs.line` and automatically maintain only the 100 most recent log entries.
 
-## VFS Modules
+## Modules
 
-Generators can use modules registered via `nu.*` topics, shared across all components and pinned by SCRU128 ID. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
+Generators can use modules registered via `nu.*` topics. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
 
 ```nushell
 r#'{
@@ -95,8 +95,6 @@ r#'{
   }
 }'# | .append log.spawn
 ```
-
-Generators do not support inline `modules` -- use VFS modules instead.
 
 ## Bi-directional Communication
 

--- a/docs/src/content/docs/reference/generators.mdx
+++ b/docs/src/content/docs/reference/generators.mdx
@@ -83,6 +83,21 @@ r#'{
 
 This generator will emit frames with the topic `logs.line` and automatically maintain only the 100 most recent log entries.
 
+## VFS Modules
+
+Generators can use modules registered via `nu.*` topics, shared across all components and pinned by SCRU128 ID. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
+
+```nushell
+r#'{
+  run: {||
+    use xs/01JAR5EXAMPLE/my-parser
+    ^tail -F data.log | lines | each {|line| my-parser parse $line }
+  }
+}'# | .append log.spawn
+```
+
+Generators do not support inline `modules` -- use VFS modules instead.
+
 ## Bi-directional Communication
 
 When `duplex` is enabled, you can send data into the generator's input pipeline

--- a/docs/src/content/docs/reference/handlers.mdx
+++ b/docs/src/content/docs/reference/handlers.mdx
@@ -99,9 +99,9 @@ The `return_options` field controls how return values are handled:
   - `"time:<milliseconds>"`: Expire after duration
   - `"last:<n>"`: Keep only N most recent frames
 
-#### Modules
+#### Inline Modules
 
-The `modules` option allows handlers to use custom Nushell modules:
+The `modules` option allows handlers to define custom Nushell modules inline:
 
 ```nushell
 r###'{
@@ -110,6 +110,19 @@ r###'{
   }
   modules: {
     "my-math": "export def double [x] { $x * 2 }"
+  }
+}'### | .append processor.register
+```
+
+#### VFS Modules
+
+Handlers can also use modules registered via `nu.*` topics. These are shared across all components and pinned by SCRU128 ID. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
+
+```nushell
+r###'{
+  run: {|frame|
+    use xs/01JAR5EXAMPLE/my-math
+    my-math double 8
   }
 }'### | .append processor.register
 ```

--- a/docs/src/content/docs/reference/handlers.mdx
+++ b/docs/src/content/docs/reference/handlers.mdx
@@ -49,11 +49,6 @@ r###'{
   # "new" (default), "first", or scru128 ID
   start: "new"
 
-  # Optional: Module definitions
-  modules: {
-    "my-math": "def double [x] { $x * 2 }"
-  }
-
   # Optional: Heartbeat interval in ms
   pulse: 1000
 
@@ -86,7 +81,6 @@ with metadata:
 | `start`          | "new" (default), "first", or scru128 ID to control where processing starts |
 | `pulse`          | Interval in milliseconds to send synthetic xs.pulse events                 |
 | `return_options` | Controls output frames: see Return Options                                 |
-| `modules`        | Map of module name to the string content of the module                     |
 
 #### Return Options
 
@@ -99,24 +93,9 @@ The `return_options` field controls how return values are handled:
   - `"time:<milliseconds>"`: Expire after duration
   - `"last:<n>"`: Keep only N most recent frames
 
-#### Inline Modules
+#### Modules
 
-The `modules` option allows handlers to define custom Nushell modules inline:
-
-```nushell
-r###'{
-  run: {|frame|
-    my-math double 8 # Use module command
-  }
-  modules: {
-    "my-math": "export def double [x] { $x * 2 }"
-  }
-}'### | .append processor.register
-```
-
-#### VFS Modules
-
-Handlers can also use modules registered via `nu.*` topics. These are shared across all components and pinned by SCRU128 ID. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
+Handlers can use modules registered via `nu.*` topics. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
 
 ```nushell
 r###'{

--- a/docs/src/content/docs/reference/handlers.mdx
+++ b/docs/src/content/docs/reference/handlers.mdx
@@ -95,7 +95,7 @@ The `return_options` field controls how return values are handled:
 
 #### Modules
 
-Handlers can use modules registered via `nu.*` topics. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
+Handlers can use modules registered via `*.nu` topics. See <Link to="/reference/topics/#module-topics">Module Topics</Link> for details.
 
 ```nushell
 r###'{

--- a/docs/src/content/docs/reference/handlers.mdx
+++ b/docs/src/content/docs/reference/handlers.mdx
@@ -100,7 +100,7 @@ Handlers can use modules registered via `*.nu` topics. See <Link to="/reference/
 ```nushell
 r###'{
   run: {|frame|
-    use xs/01JAR5EXAMPLE/my-math
+    use xs/my-math
     my-math double 8
   }
 }'### | .append processor.register

--- a/docs/src/content/docs/reference/topics.mdx
+++ b/docs/src/content/docs/reference/topics.mdx
@@ -51,6 +51,35 @@ Use `*` alone to match all topics (equivalent to omitting `--topic`).
 
 Topic queries return frames in chronological order (by frame ID), not grouped by topic. Both historical reads and live follows maintain this ordering.
 
+## Module Topics
+
+Topics prefixed with `nu.` register Nushell modules into the virtual filesystem (VFS). Any handler, generator, or command script can then `use` these modules by their SCRU128 ID.
+
+```nushell
+# Register a module
+r#'export def greet [name: string] { $"hello ($name)" }'# | .append nu.mymod
+```
+
+The topic name maps to a directory path -- dots become slashes:
+
+| Topic | VFS Path |
+| ----- | -------- |
+| `nu.mymod` | `xs/<id>/mymod/mod.nu` |
+| `nu.discord.api` | `xs/<id>/discord/api/mod.nu` |
+
+Scripts reference modules by SCRU128 ID, pinning to an exact version:
+
+```nushell
+r#'{
+  run: {|frame|
+    use xs/01JAR5EXAMPLE/mymod
+    mymod greet "world"
+  }
+}'# | .append greeter.register
+```
+
+Modules appended before startup are available to all scripts. Modules appended at runtime are available to scripts registered after them.
+
 ## Component Suffixes
 
 cross.stream uses topic suffixes to coordinate component lifecycle.

--- a/docs/src/content/docs/reference/topics.mdx
+++ b/docs/src/content/docs/reference/topics.mdx
@@ -53,19 +53,19 @@ Topic queries return frames in chronological order (by frame ID), not grouped by
 
 ## Module Topics
 
-Topics prefixed with `nu.` register Nushell modules into the virtual filesystem (VFS). Any handler, generator, or command script can then `use` these modules by their SCRU128 ID.
+Topics ending with `.nu` register Nushell modules into the virtual filesystem (VFS). Any handler, generator, or command script can then `use` these modules by their SCRU128 ID.
 
 ```nushell
 # Register a module
-r#'export def greet [name: string] { $"hello ($name)" }'# | .append nu.mymod
+r#'export def greet [name: string] { $"hello ($name)" }'# | .append mymod.nu
 ```
 
-The topic name maps to a directory path -- dots become slashes:
+The topic name (minus the `.nu` suffix) maps to a directory path -- dots become slashes:
 
 | Topic | VFS Path |
 | ----- | -------- |
-| `nu.mymod` | `xs/<id>/mymod/mod.nu` |
-| `nu.discord.api` | `xs/<id>/discord/api/mod.nu` |
+| `mymod.nu` | `xs/<id>/mymod/mod.nu` |
+| `discord.api.nu` | `xs/<id>/discord/api/mod.nu` |
 
 Scripts reference modules by SCRU128 ID, pinning to an exact version:
 

--- a/docs/src/content/docs/reference/topics.mdx
+++ b/docs/src/content/docs/reference/topics.mdx
@@ -53,7 +53,7 @@ Topic queries return frames in chronological order (by frame ID), not grouped by
 
 ## Module Topics
 
-Topics ending with `.nu` register Nushell modules into the virtual filesystem (VFS). Any handler, generator, or command script can then `use` these modules by their SCRU128 ID.
+Topics ending with `.nu` register Nushell modules into the virtual filesystem (VFS). Any handler, generator, or command script can then `use` these modules by their stable VFS path.
 
 ```nushell
 # Register a module
@@ -64,15 +64,15 @@ The topic name (minus the `.nu` suffix) maps to a directory path -- dots become 
 
 | Topic | VFS Path |
 | ----- | -------- |
-| `mymod.nu` | `xs/<id>/mymod/mod.nu` |
-| `discord.api.nu` | `xs/<id>/discord/api/mod.nu` |
+| `mymod.nu` | `xs/mymod/mod.nu` |
+| `discord.api.nu` | `xs/discord/api/mod.nu` |
 
-Scripts reference modules by SCRU128 ID, pinning to an exact version:
+Scripts reference modules by their stable VFS path. Re-appending a module topic shadows the previous version:
 
 ```nushell
 r#'{
   run: {|frame|
-    use xs/01JAR5EXAMPLE/mymod
+    use xs/mymod
     mymod greet "world"
   }
 }'# | .append greeter.register

--- a/examples/discord-bot/handler-bookmarklet.nu
+++ b/examples/discord-bot/handler-bookmarklet.nu
@@ -16,7 +16,7 @@
             if $message.d.emoji.name != "🔖" { return }
 
             let bookmarks = (
-                .head "bookmarks" | if ($in | is-not-empty)  {
+                .last "bookmarks" | if ($in | is-not-empty)  {
                     $in | .cas | from json
                 } else { {} })
 
@@ -29,7 +29,7 @@
             if $message.d.emoji.name != "🔖" { return }
 
             let bookmarks = (
-                .head "bookmarks" | if ($in | is-not-empty)  {
+                .last "bookmarks" | if ($in | is-not-empty)  {
                     $in | .cas | from json
                 } else { {} })
 

--- a/examples/discord-bot/handler-heartbeat.nu
+++ b/examples/discord-bot/handler-heartbeat.nu
@@ -67,10 +67,10 @@ $env.state = {
     resume_gateway_url: null
   }
 
-$env.BOT_TOKEN = .head discord.ws.token | .cas $in.hash
+$env.BOT_TOKEN = .last discord.ws.token | .cas $in.hash
 
 {
-  resume_from: (.head discord.ws.running | if ($in | is-not-empty) { get id })
+  start: (.last discord.ws.running | get -i id | default "first")
   pulse: 1000
 
   run: {|frame|

--- a/examples/discord-bot/handler-roller.nu
+++ b/examples/discord-bot/handler-roller.nu
@@ -29,12 +29,11 @@ def run-roll [] {
   $content
 }
 
-$env.BOT_TOKEN = .head discord.ws.token | .cas $in.hash
+$env.BOT_TOKEN = .last discord.ws.token | .cas $in.hash
 
 {
-  modules: {discord: (.head discord.nu | .cas $in.hash)}
-
   run: {|frame|
+    use xs/discord
     if $frame.topic != "discord.ws.recv" { return }
 
     # TODO: .cas should also be able to take a record, to match xs2.nu's usage

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,4 +3,4 @@ mod serve;
 #[cfg(test)]
 mod tests;
 
-pub use serve::serve;
+pub use serve::CommandRegistry;

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -271,7 +271,7 @@ async fn setup_test_environment() -> (TempDir, Store) {
     {
         let store = store.clone();
         drop(tokio::spawn(async move {
-            crate::commands::serve::serve(store, engine.clone())
+            crate::dispatcher::serve(store, engine.clone())
                 .await
                 .unwrap();
         }));

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1,0 +1,45 @@
+use crate::commands::CommandRegistry;
+use crate::generators::GeneratorRegistry;
+use crate::handlers::HandlerRegistry;
+use crate::nu;
+use crate::store::{FollowOption, ReadOptions, Store};
+
+pub async fn serve(
+    store: Store,
+    engine: nu::Engine,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut engine = engine;
+    nu::add_core_commands(&mut engine, &store)?;
+    engine.add_alias(".rm", ".remove")?;
+
+    let mut handlers = HandlerRegistry::new();
+    let mut generators = GeneratorRegistry::new();
+    let mut commands = CommandRegistry::new();
+
+    let options = ReadOptions::builder().follow(FollowOption::On).build();
+    let mut recver = store.read(options).await;
+
+    // Phase 1: Historical replay
+    while let Some(frame) = recver.recv().await {
+        if frame.topic == "xs.threshold" {
+            break;
+        }
+        handlers.process_historical(&frame);
+        generators.process_historical(&frame);
+        commands.process_historical(&frame, &engine, &store).await;
+    }
+
+    // Phase 2: Materialize
+    handlers.materialize(&store, &engine).await?;
+    generators.materialize(&store, &engine).await?;
+    commands.materialize(&store, &engine).await?;
+
+    // Phase 3: Live
+    while let Some(frame) = recver.recv().await {
+        handlers.process_live(&frame, &store, &engine).await?;
+        generators.process_live(&frame, &store, &engine).await?;
+        commands.process_live(&frame, &store, &engine).await?;
+    }
+
+    Ok(())
+}

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -2,6 +2,7 @@ use crate::commands::CommandRegistry;
 use crate::generators::GeneratorRegistry;
 use crate::handlers::HandlerRegistry;
 use crate::nu;
+use crate::nu::ModuleRegistry;
 use crate::store::{FollowOption, ReadOptions, Store};
 
 pub async fn serve(
@@ -12,6 +13,7 @@ pub async fn serve(
     nu::add_core_commands(&mut engine, &store)?;
     engine.add_alias(".rm", ".remove")?;
 
+    let mut modules = ModuleRegistry::new();
     let mut handlers = HandlerRegistry::new();
     let mut generators = GeneratorRegistry::new();
     let mut commands = CommandRegistry::new();
@@ -24,18 +26,21 @@ pub async fn serve(
         if frame.topic == "xs.threshold" {
             break;
         }
+        modules.process_historical(&frame);
         handlers.process_historical(&frame);
         generators.process_historical(&frame);
         commands.process_historical(&frame, &engine, &store).await;
     }
 
-    // Phase 2: Materialize
+    // Phase 2: Materialize — modules first so VFS is populated before scripts are parsed
+    modules.materialize(&store, &mut engine).await?;
     handlers.materialize(&store, &engine).await?;
     generators.materialize(&store, &engine).await?;
     commands.materialize(&store, &engine).await?;
 
-    // Phase 3: Live
+    // Phase 3: Live — modules process before others for same reason
     while let Some(frame) = recver.recv().await {
+        modules.process_live(&frame, &store, &mut engine).await?;
         handlers.process_live(&frame, &store, &engine).await?;
         generators.process_live(&frame, &store, &engine).await?;
         commands.process_live(&frame, &store, &engine).await?;

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -13,7 +13,7 @@ pub async fn serve(
     nu::add_core_commands(&mut engine, &store)?;
     engine.add_alias(".rm", ".remove")?;
 
-    let mut modules = ModuleRegistry::new();
+    let mut modules = ModuleRegistry;
     let mut handlers = HandlerRegistry::new();
     let mut generators = GeneratorRegistry::new();
     let mut commands = CommandRegistry::new();

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod generator;
-pub(crate) mod serve;
+mod serve;
 
 pub use generator::{
     spawn as spawn_generator_loop, GeneratorEventKind, GeneratorLoop, GeneratorScriptOptions,

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -1,5 +1,5 @@
-mod generator;
-mod serve;
+pub(crate) mod generator;
+pub(crate) mod serve;
 
 pub use generator::{
     spawn as spawn_generator_loop, GeneratorEventKind, GeneratorLoop, GeneratorScriptOptions,
@@ -9,4 +9,4 @@ pub use generator::{
 #[cfg(test)]
 mod tests;
 
-pub use serve::serve;
+pub use serve::GeneratorRegistry;

--- a/src/generators/serve.rs
+++ b/src/generators/serve.rs
@@ -89,9 +89,9 @@ impl GeneratorRegistry {
         &mut self,
         store: &Store,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        for (topic, (frame, engine)) in &self.compacted {
+        for (topic, (frame, engine)) in self.compacted.drain() {
             if frame.topic.ends_with(".spawn") {
-                try_start_task(topic, frame, &mut self.active, engine, store).await;
+                try_start_task(&topic, &frame, &mut self.active, &engine, store).await;
             }
         }
         Ok(())

--- a/src/generators/serve.rs
+++ b/src/generators/serve.rs
@@ -5,7 +5,7 @@ use tokio::task::JoinHandle;
 
 use crate::generators::generator;
 use crate::nu;
-use crate::store::{FollowOption, Frame, ReadOptions, Store};
+use crate::store::{Frame, Store};
 
 async fn try_start_task(
     topic: &str,
@@ -56,55 +56,67 @@ async fn handle_spawn_event(
     Ok(())
 }
 
-pub async fn serve(
-    store: Store,
-    engine: nu::Engine,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let options = ReadOptions::builder().follow(FollowOption::On).build();
-    let mut recver = store.read(options).await;
+#[derive(Default)]
+pub struct GeneratorRegistry {
+    active: HashMap<String, JoinHandle<()>>,
+    compacted: HashMap<String, Frame>,
+}
 
-    let mut active: HashMap<String, JoinHandle<()>> = HashMap::new();
-    let mut compacted: HashMap<String, Frame> = HashMap::new();
-
-    while let Some(frame) = recver.recv().await {
-        if frame.topic == "xs.threshold" {
-            break;
+impl GeneratorRegistry {
+    pub fn new() -> Self {
+        Self {
+            active: HashMap::new(),
+            compacted: HashMap::new(),
         }
+    }
+
+    pub fn process_historical(&mut self, frame: &Frame) {
         if frame.topic.ends_with(".spawn") || frame.topic.ends_with(".parse.error") {
             if let Some(prefix) = frame
                 .topic
                 .strip_suffix(".parse.error")
                 .or_else(|| frame.topic.strip_suffix(".spawn"))
             {
-                compacted.insert(prefix.to_string(), frame);
+                self.compacted.insert(prefix.to_string(), frame.clone());
             }
         } else if let Some(prefix) = frame.topic.strip_suffix(".terminate") {
-            compacted.remove(prefix);
+            self.compacted.remove(prefix);
         }
     }
 
-    for (topic, frame) in &compacted {
-        if frame.topic.ends_with(".spawn") {
-            try_start_task(topic, frame, &mut active, &engine, &store).await;
+    pub async fn materialize(
+        &mut self,
+        store: &Store,
+        engine: &nu::Engine,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        for (topic, frame) in &self.compacted {
+            if frame.topic.ends_with(".spawn") {
+                try_start_task(topic, frame, &mut self.active, engine, store).await;
+            }
         }
+        Ok(())
     }
 
-    while let Some(frame) = recver.recv().await {
+    pub async fn process_live(
+        &mut self,
+        frame: &Frame,
+        store: &Store,
+        engine: &nu::Engine,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if let Some(prefix) = frame.topic.strip_suffix(".spawn") {
-            try_start_task(prefix, &frame, &mut active, &engine, &store).await;
-            continue;
+            try_start_task(prefix, frame, &mut self.active, engine, store).await;
+            return Ok(());
         }
 
-        if let Some(_prefix) = frame.topic.strip_suffix(".parse.error") {
+        if frame.topic.ends_with(".parse.error") {
             // parse.error frames are informational; ignore them
-            continue;
+            return Ok(());
         }
 
         if let Some(prefix) = frame.topic.strip_suffix(".shutdown") {
-            active.remove(prefix);
-            continue;
+            self.active.remove(prefix);
         }
-    }
 
-    Ok(())
+        Ok(())
+    }
 }

--- a/src/generators/tests.rs
+++ b/src/generators/tests.rs
@@ -367,7 +367,7 @@ async fn test_parse_error_eviction() {
 
     // no stop frame should be emitted on parse error
 
-    // Allow ServeLoop to process the parse.error and evict the generator
+    // Allow the dispatcher to process the parse.error and evict the generator
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let good_script = r#"{ run: {|| "ok" } }"#;

--- a/src/generators/tests.rs
+++ b/src/generators/tests.rs
@@ -1,5 +1,6 @@
-use super::*;
+use crate::dispatcher;
 use crate::generators::generator::emit_event;
+use crate::generators::{GeneratorEventKind, GeneratorLoop, StopReason, Task};
 use crate::nu::ReturnOptions;
 use nu_protocol;
 use scru128;
@@ -23,7 +24,7 @@ async fn test_serve_basic() {
     {
         let store = store.clone();
         drop(tokio::spawn(async move {
-            serve(store, engine).await.unwrap();
+            dispatcher::serve(store, engine).await.unwrap();
         }));
     }
 
@@ -70,7 +71,7 @@ async fn test_serve_duplex() {
     {
         let store = store.clone();
         drop(tokio::spawn(async move {
-            serve(store, engine).await.unwrap();
+            dispatcher::serve(store, engine).await.unwrap();
         }));
     }
 
@@ -145,7 +146,7 @@ async fn test_serve_compact() {
     {
         let store = store.clone();
         drop(tokio::spawn(async move {
-            serve(store, engine).await.unwrap();
+            dispatcher::serve(store, engine).await.unwrap();
         }));
     }
 
@@ -183,7 +184,7 @@ async fn test_respawn_after_terminate() {
         let store = store.clone();
         let engine = engine.clone();
         tokio::spawn(async move {
-            serve(store, engine).await.unwrap();
+            dispatcher::serve(store, engine).await.unwrap();
         });
     }
 
@@ -232,7 +233,7 @@ async fn test_serve_restart_until_terminated() {
         let store = store.clone();
         let engine = engine.clone();
         tokio::spawn(async move {
-            serve(store, engine).await.unwrap();
+            dispatcher::serve(store, engine).await.unwrap();
         });
     }
 
@@ -288,7 +289,7 @@ async fn test_duplex_terminate_stops() {
         let store = store.clone();
         let engine = engine.clone();
         tokio::spawn(async move {
-            serve(store, engine).await.unwrap();
+            dispatcher::serve(store, engine).await.unwrap();
         });
     }
 
@@ -338,7 +339,7 @@ async fn test_parse_error_eviction() {
         let store = store.clone();
         let engine = engine.clone();
         tokio::spawn(async move {
-            serve(store, engine).await.unwrap();
+            dispatcher::serve(store, engine).await.unwrap();
         });
     }
 
@@ -397,7 +398,7 @@ async fn test_refresh_on_new_spawn() {
         let store = store.clone();
         let engine = engine.clone();
         tokio::spawn(async move {
-            serve(store, engine).await.unwrap();
+            dispatcher::serve(store, engine).await.unwrap();
         });
     }
 
@@ -459,7 +460,7 @@ async fn test_terminate_one_of_two_generators() {
     {
         let store = store.clone();
         let engine = engine.clone();
-        tokio::spawn(async move { serve(store, engine).await.unwrap() });
+        tokio::spawn(async move { dispatcher::serve(store, engine).await.unwrap() });
     }
 
     let options = ReadOptions::builder()
@@ -515,7 +516,7 @@ async fn test_bytestream_ping() {
     {
         let store = store.clone();
         let engine = engine.clone();
-        tokio::spawn(async move { serve(store, engine).await.unwrap() });
+        tokio::spawn(async move { dispatcher::serve(store, engine).await.unwrap() });
     }
 
     let options = ReadOptions::builder()
@@ -659,7 +660,7 @@ async fn test_external_command_error_message() {
         let store = store.clone();
         let engine = engine.clone();
         tokio::spawn(async move {
-            serve(store, engine).await.unwrap();
+            dispatcher::serve(store, engine).await.unwrap();
         });
     }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,7 +1,7 @@
 mod handler;
-mod serve;
+pub(crate) mod serve;
 #[cfg(test)]
 mod tests;
 
 pub use handler::Handler;
-pub use serve::serve;
+pub use serve::HandlerRegistry;

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,5 +1,5 @@
 mod handler;
-pub(crate) mod serve;
+mod serve;
 #[cfg(test)]
 mod tests;
 

--- a/src/handlers/serve.rs
+++ b/src/handlers/serve.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::handlers::Handler;
 use crate::nu;
-use crate::store::{FollowOption, Frame, ReadOptions, Store};
+use crate::store::{Frame, Store};
 
 async fn start_handler(
     frame: &Frame,
@@ -35,30 +35,23 @@ struct TopicState {
     handler_id: String,
 }
 
-pub async fn serve(
-    store: Store,
-    mut engine: nu::Engine,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    nu::add_core_commands(&mut engine, &store)?;
-    engine.add_alias(".rm", ".remove")?;
+#[derive(Default)]
+pub struct HandlerRegistry {
+    topic_states: HashMap<String, TopicState>,
+}
 
-    let options = ReadOptions::builder().follow(FollowOption::On).build();
-
-    let mut recver = store.read(options).await;
-    let mut topic_states: HashMap<String, TopicState> = HashMap::new();
-
-    // Process historical frames until threshold
-    while let Some(frame) = recver.recv().await {
-        if frame.topic == "xs.threshold" {
-            break;
+impl HandlerRegistry {
+    pub fn new() -> Self {
+        Self {
+            topic_states: HashMap::new(),
         }
+    }
 
-        // Extract base topic and suffix
+    pub fn process_historical(&mut self, frame: &Frame) {
         if let Some((topic, suffix)) = frame.topic.rsplit_once('.') {
             match suffix {
                 "register" => {
-                    // Store new registration
-                    topic_states.insert(
+                    self.topic_states.insert(
                         topic.to_string(),
                         TopicState {
                             register_frame: frame.clone(),
@@ -67,13 +60,12 @@ pub async fn serve(
                     );
                 }
                 "unregister" | "inactive" => {
-                    // Only remove if handler_id matches
                     if let Some(meta) = &frame.meta {
                         if let Some(handler_id) = meta.get("handler_id").and_then(|v| v.as_str()) {
                             let key = topic.to_string();
-                            if let Some(state) = topic_states.get(&key) {
+                            if let Some(state) = self.topic_states.get(&key) {
                                 if state.handler_id == handler_id {
-                                    topic_states.remove(&key);
+                                    self.topic_states.remove(&key);
                                 }
                             }
                         }
@@ -84,22 +76,32 @@ pub async fn serve(
         }
     }
 
-    // Process all retained registrations ordered by frame ID
-    let mut ordered_states: Vec<_> = topic_states.values().collect();
-    ordered_states.sort_by_key(|state| state.register_frame.id);
+    pub async fn materialize(
+        &mut self,
+        store: &Store,
+        engine: &nu::Engine,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let mut ordered_states: Vec<_> = self.topic_states.values().collect();
+        ordered_states.sort_by_key(|state| state.register_frame.id);
 
-    for state in ordered_states {
-        if let Some(topic) = state.register_frame.topic.strip_suffix(".register") {
-            start_handler(&state.register_frame, &store, &engine, topic).await?;
+        for state in ordered_states {
+            if let Some(topic) = state.register_frame.topic.strip_suffix(".register") {
+                start_handler(&state.register_frame, store, engine, topic).await?;
+            }
         }
+
+        Ok(())
     }
 
-    // Continue processing new frames
-    while let Some(frame) = recver.recv().await {
+    pub async fn process_live(
+        &mut self,
+        frame: &Frame,
+        store: &Store,
+        engine: &nu::Engine,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if let Some(topic) = frame.topic.strip_suffix(".register") {
-            start_handler(&frame, &store, &engine, topic).await?;
+            start_handler(frame, store, engine, topic).await?;
         }
+        Ok(())
     }
-
-    Ok(())
 }

--- a/src/handlers/serve.rs
+++ b/src/handlers/serve.rs
@@ -47,10 +47,8 @@ impl HandlerRegistry {
         if let Some((topic, suffix)) = frame.topic.rsplit_once('.') {
             match suffix {
                 "register" => {
-                    self.compacted.insert(
-                        topic.to_string(),
-                        (frame.clone(), engine.clone()),
-                    );
+                    self.compacted
+                        .insert(topic.to_string(), (frame.clone(), engine.clone()));
                 }
                 "unregister" | "inactive" => {
                     if let Some(meta) = &frame.meta {

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -1,7 +1,7 @@
 use tempfile::TempDir;
 
+use crate::dispatcher;
 use crate::error::Error;
-use crate::handlers::serve;
 use crate::nu;
 use crate::store::TTL;
 use crate::store::{FollowOption, Frame, ReadOptions, Store};
@@ -829,7 +829,7 @@ async fn setup_test_environment() -> (Store, TempDir) {
     {
         let store = store.clone();
         drop(tokio::spawn(async move {
-            serve(store, engine).await.unwrap();
+            dispatcher::serve(store, engine).await.unwrap();
         }));
     }
 

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -659,10 +659,10 @@ async fn test_handler_with_module() -> Result<(), Error> {
     let mut recver = store.read(options).await;
     assert_eq!(recver.recv().await.unwrap().topic, "xs.threshold");
 
-    // Register a VFS module via nu.* topic
+    // Register a VFS module via *.nu topic
     let module_frame = store
         .append(
-            Frame::builder("nu.mymod")
+            Frame::builder("mymod.nu")
                 .hash(
                     store
                         .cas_insert(
@@ -678,7 +678,7 @@ async fn test_handler_with_module() -> Result<(), Error> {
                 .build(),
         )
         .unwrap();
-    assert_eq!(recver.recv().await.unwrap().topic, "nu.mymod");
+    assert_eq!(recver.recv().await.unwrap().topic, "mymod.nu");
 
     let module_id = module_frame.id.to_string();
 

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -660,7 +660,7 @@ async fn test_handler_with_module() -> Result<(), Error> {
     assert_eq!(recver.recv().await.unwrap().topic, "xs.threshold");
 
     // Register a VFS module via *.nu topic
-    let module_frame = store
+    store
         .append(
             Frame::builder("mymod.nu")
                 .hash(
@@ -680,18 +680,14 @@ async fn test_handler_with_module() -> Result<(), Error> {
         .unwrap();
     assert_eq!(recver.recv().await.unwrap().topic, "mymod.nu");
 
-    let module_id = module_frame.id.to_string();
-
     // Create handler that uses the VFS module
-    let handler_script = format!(
-        r#"{{
-            run: {{|frame|
-                if $frame.topic != "trigger" {{ return }}
-                use xs/{module_id}/mymod
+    let handler_script = r#"{
+            run: {|frame|
+                if $frame.topic != "trigger" { return }
+                use xs/mymod
                 mymod add_nums 40 2
-            }}
-        }}"#
-    );
+            }
+        }"#;
     let frame_handler = store
         .append(
             Frame::builder("test.register")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod client;
 pub mod commands;
+pub mod dispatcher;
 pub mod error;
 pub mod generators;
 pub mod handlers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,23 +332,7 @@ async fn serve(args: CommandServe) -> Result<(), Box<dyn std::error::Error + Sen
         let store = store.clone();
         let engine = engine.clone();
         tokio::spawn(async move {
-            let _ = xs::generators::serve(store, engine).await;
-        });
-    }
-
-    {
-        let store = store.clone();
-        let engine = engine.clone();
-        tokio::spawn(async move {
-            let _ = xs::handlers::serve(store, engine).await;
-        });
-    }
-
-    {
-        let store = store.clone();
-        let engine = engine.clone();
-        tokio::spawn(async move {
-            let _ = xs::commands::serve(store, engine).await;
+            let _ = xs::dispatcher::serve(store, engine).await;
         });
     }
 

--- a/src/nu/config.rs
+++ b/src/nu/config.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use nu_engine::eval_block_with_early_return;
 use nu_parser::parse;
 use nu_protocol::debugger::WithoutDebug;
@@ -26,7 +24,7 @@ impl NuScriptConfig {
     ///
     /// The type `T` must implement `serde::Deserialize`.
     /// This is a convenience for callers to extract custom fields from the script's
-    /// configuration record after `run` and `modules` have been processed.
+    /// configuration record after `run` has been processed.
     pub fn deserialize_options<T>(&self) -> Result<T, Error>
     where
         T: for<'de> serde::Deserialize<'de>,
@@ -46,120 +44,18 @@ pub struct ReturnOptions {
     pub ttl: Option<TTL>,
 }
 
-/// For backward compatibility
-/// @deprecated Use NuScriptConfig instead
-pub struct CommonOptions {
-    /// The run closure that will be executed
-    pub run: Closure,
-    /// Map of module names to module content
-    pub modules: HashMap<String, String>,
-    /// Optional customization for return frame format
-    pub return_options: Option<ReturnOptions>,
-}
-
 /// Parse a script into a NuScriptConfig struct.
 ///
-/// This function parses a Nushell script, loads its defined modules, and extracts the `run` closure
-/// and the full configuration value.
-///
-/// The process involves:
-/// 1. A first pass evaluation of the script to extract `modules` definitions.
-/// 2. Loading these modules into the provided `engine`.
-/// 3. A second pass evaluation (of the main script block) to obtain the `run` closure
-///    (which can now reference the loaded modules) and the script's full output Value.
+/// Parses and evaluates the script, then extracts the `run` closure and the full
+/// configuration value. VFS modules (registered via `nu.*` topics) are already
+/// available on the engine state before this function is called.
 pub fn parse_config(engine: &mut crate::nu::Engine, script: &str) -> Result<NuScriptConfig, Error> {
-    // --- Pass 1: Extract modules and initial config value ---
-    // We need to evaluate the script once to see what modules it *wants* to define.
-    let (_initial_config_value, modules_to_load) = {
-        let mut temp_engine_state = engine.state.clone(); // Use a temporary state for the first pass
-        let mut temp_working_set = StateWorkingSet::new(&temp_engine_state);
-        let temp_block = parse(&mut temp_working_set, None, script.as_bytes(), false);
-
-        // Handle parse errors from first pass
-        if let Some(err) = temp_working_set.parse_errors.first() {
-            let shell_error = ShellError::GenericError {
-                error: "Parse error in script (initial pass)".into(),
-                msg: format!("{err:?}"),
-                span: Some(err.span()),
-                help: None,
-                inner: vec![],
-            };
-            return Err(Error::from(nu_protocol::format_cli_error(
-                None,
-                &temp_working_set,
-                &shell_error,
-                None,
-            )));
-        }
-        temp_engine_state.merge_delta(temp_working_set.render())?;
-
-        let mut temp_stack = Stack::new();
-        let eval_result = eval_block_with_early_return::<WithoutDebug>(
-            &temp_engine_state,
-            &mut temp_stack,
-            &temp_block,
-            PipelineData::empty(),
-        )
-        .map_err(|err| {
-            let working_set = nu_protocol::engine::StateWorkingSet::new(&temp_engine_state);
-            Error::from(nu_protocol::format_cli_error(
-                None,
-                &working_set,
-                &err,
-                None,
-            ))
-        })?;
-        let val = eval_result.body.into_value(Span::unknown())?;
-
-        let modules = match val.get_data_by_key("modules") {
-            Some(mod_val) => {
-                let record = mod_val
-                    .as_record()
-                    .map_err(|_| -> Error { "modules field must be a record".into() })?;
-                record
-                    .iter()
-                    .map(|(name, content_val)| {
-                        let content_str = content_val
-                            .as_str()
-                            .map_err(|_| -> Error {
-                                format!(
-                                    "Module '{name}' content must be a string, got {typ:?}",
-                                    name = name,
-                                    typ = content_val.get_type()
-                                )
-                                .into()
-                            })?
-                            .to_string();
-                        Ok((name.to_string(), content_str))
-                    })
-                    .collect::<Result<HashMap<String, String>, Error>>()?
-            }
-            None => HashMap::new(),
-        };
-        temp_engine_state.merge_env(&mut temp_stack)?; // Merge env from first pass to temp_engine_state
-        (val, modules)
-    };
-
-    // --- Load modules into the main engine ---
-    if !modules_to_load.is_empty() {
-        for (name, content) in &modules_to_load {
-            tracing::debug!("Loading module '{}' into main engine", name);
-            engine
-                .add_module(name, content)
-                .map_err(|e| -> Error { format!("Failed to load module '{name}': {e}").into() })?;
-        }
-    }
-
-    // --- Pass 2: Parse and evaluate with modules loaded to get final closure and config ---
-    // Now, the main `engine` has the modules loaded.
-    // We re-parse and re-evaluate the script's main block using this module-aware engine.
-    // This ensures the 'run' closure correctly captures items from the loaded modules.
     let mut working_set = StateWorkingSet::new(&engine.state);
     let block = parse(&mut working_set, None, script.as_bytes(), false);
 
     if let Some(err) = working_set.parse_errors.first() {
         let shell_error = ShellError::GenericError {
-            error: "Parse error in script (final pass)".into(),
+            error: "Parse error in script".into(),
             msg: format!("{err:?}"),
             span: Some(err.span()),
             help: None,
@@ -173,7 +69,6 @@ pub fn parse_config(engine: &mut crate::nu::Engine, script: &str) -> Result<NuSc
         )));
     }
 
-    // Handle compile errors
     if let Some(err) = working_set.compile_errors.first() {
         let shell_error = ShellError::GenericError {
             error: "Compile error in script".into(),
@@ -193,14 +88,14 @@ pub fn parse_config(engine: &mut crate::nu::Engine, script: &str) -> Result<NuSc
     engine.state.merge_delta(working_set.render())?;
 
     let mut stack = Stack::new();
-    let final_eval_result = eval_block_with_early_return::<WithoutDebug>(
+    let eval_result = eval_block_with_early_return::<WithoutDebug>(
         &engine.state,
         &mut stack,
         &block,
         PipelineData::empty(),
     )
     .map_err(|err| {
-        let working_set = nu_protocol::engine::StateWorkingSet::new(&engine.state); // Use main engine for error formatting
+        let working_set = StateWorkingSet::new(&engine.state);
         Error::from(nu_protocol::format_cli_error(
             None,
             &working_set,
@@ -209,86 +104,19 @@ pub fn parse_config(engine: &mut crate::nu::Engine, script: &str) -> Result<NuSc
         ))
     })?;
 
-    let final_config_value = final_eval_result.body.into_value(Span::unknown())?;
+    let config_value = eval_result.body.into_value(Span::unknown())?;
 
-    let run_val = final_config_value
+    let run_val = config_value
         .get_data_by_key("run")
         .ok_or_else(|| -> Error { "Script must define a 'run' closure.".into() })?;
     let run_closure = run_val
         .as_closure()
         .map_err(|e| -> Error { format!("'run' field must be a closure: {e}").into() })?;
 
-    engine.state.merge_env(&mut stack)?; // Merge env from final pass to main engine
+    engine.state.merge_env(&mut stack)?;
 
     Ok(NuScriptConfig {
         run_closure: run_closure.clone(),
-        full_config_value: final_config_value,
-    })
-}
-
-/// For backward compatibility
-/// @deprecated Use parse_config with NuScriptConfig instead
-pub fn parse_config_legacy(
-    engine: &mut crate::nu::Engine,
-    script: &str,
-) -> Result<CommonOptions, Error> {
-    // Use the new parsing function
-    let script_config = parse_config(engine, script)?;
-
-    // Extract values as needed for CommonOptions
-    let modules = match script_config.full_config_value.get_data_by_key("modules") {
-        Some(val) => {
-            let record = val
-                .as_record()
-                .map_err(|_| -> Error { "modules must be a record".into() })?;
-            record
-                .iter()
-                .map(|(name, content)| {
-                    let content = content
-                        .as_str()
-                        .map_err(|_| -> Error {
-                            format!("module '{name}' content must be a string").into()
-                        })?
-                        .to_string();
-                    Ok((name.to_string(), content))
-                })
-                .collect::<Result<HashMap<_, _>, Error>>()?
-        }
-        None => HashMap::new(),
-    };
-
-    // Parse return_options (optional)
-    let return_options = if let Some(return_config) = script_config
-        .full_config_value
-        .get_data_by_key("return_options")
-    {
-        let record = return_config
-            .as_record()
-            .map_err(|_| -> Error { "return_options must be a record".into() })?;
-
-        let suffix = record
-            .get("suffix")
-            .map(|v| {
-                v.as_str()
-                    .map_err(|_| -> Error { "suffix must be a string".into() })
-                    .map(|s| s.to_string())
-            })
-            .transpose()?;
-
-        let ttl = record
-            .get("ttl")
-            .map(|v| serde_json::from_str(&value_to_json(v).to_string()))
-            .transpose()
-            .map_err(|e| -> Error { format!("invalid TTL: {e}").into() })?;
-
-        Some(ReturnOptions { suffix, ttl })
-    } else {
-        None
-    };
-
-    Ok(CommonOptions {
-        run: script_config.run_closure,
-        modules,
-        return_options,
+        full_config_value: config_value,
     })
 }

--- a/src/nu/config.rs
+++ b/src/nu/config.rs
@@ -47,7 +47,7 @@ pub struct ReturnOptions {
 /// Parse a script into a NuScriptConfig struct.
 ///
 /// Parses and evaluates the script, then extracts the `run` closure and the full
-/// configuration value. VFS modules (registered via `nu.*` topics) are already
+/// configuration value. VFS modules (registered via `*.nu` topics) are already
 /// available on the engine state before this function is called.
 pub fn parse_config(engine: &mut crate::nu::Engine, script: &str) -> Result<NuScriptConfig, Error> {
     let mut working_set = StateWorkingSet::new(&engine.state);

--- a/src/nu/mod.rs
+++ b/src/nu/mod.rs
@@ -13,3 +13,5 @@ pub use vfs::ModuleRegistry;
 mod test_commands;
 #[cfg(test)]
 mod test_engine;
+#[cfg(test)]
+mod test_vfs;

--- a/src/nu/mod.rs
+++ b/src/nu/mod.rs
@@ -4,7 +4,7 @@ pub mod vfs;
 
 pub mod commands;
 pub mod util;
-pub use config::{parse_config, parse_config_legacy, CommonOptions, NuScriptConfig, ReturnOptions};
+pub use config::{parse_config, NuScriptConfig, ReturnOptions};
 pub use engine::{add_core_commands, Engine};
 pub use util::{frame_to_pipeline, frame_to_value, value_to_json};
 pub use vfs::ModuleRegistry;

--- a/src/nu/mod.rs
+++ b/src/nu/mod.rs
@@ -1,11 +1,13 @@
 mod config;
 mod engine;
+pub mod vfs;
 
 pub mod commands;
 pub mod util;
 pub use config::{parse_config, parse_config_legacy, CommonOptions, NuScriptConfig, ReturnOptions};
 pub use engine::{add_core_commands, Engine};
 pub use util::{frame_to_pipeline, frame_to_value, value_to_json};
+pub use vfs::ModuleRegistry;
 
 #[cfg(test)]
 mod test_commands;

--- a/src/nu/test_vfs.rs
+++ b/src/nu/test_vfs.rs
@@ -1,0 +1,304 @@
+use tempfile::TempDir;
+
+use crate::dispatcher;
+use crate::nu;
+use crate::nu::vfs::ModuleRegistry;
+use crate::store::{FollowOption, Frame, ReadOptions, Store};
+
+async fn setup_test_environment() -> (Store, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let store = Store::new(temp_dir.path().to_path_buf()).unwrap();
+    let engine = nu::Engine::new().unwrap();
+
+    {
+        let store = store.clone();
+        drop(tokio::spawn(async move {
+            dispatcher::serve(store, engine).await.unwrap();
+        }));
+    }
+
+    (store, temp_dir)
+}
+
+async fn assert_no_more_frames(recver: &mut tokio::sync::mpsc::Receiver<Frame>) {
+    let timeout = tokio::time::sleep(std::time::Duration::from_millis(50));
+    tokio::pin!(timeout);
+    tokio::select! {
+        Some(frame) = recver.recv() => {
+            panic!("Unexpected frame processed: {:?}", frame);
+        }
+        _ = &mut timeout => {
+            // Success - no additional frames were processed
+        }
+    }
+}
+
+// --- Unit tests for ModuleRegistry ---
+
+#[test]
+fn test_process_historical_collects_nu_frames() {
+    let mut registry = ModuleRegistry::new();
+
+    let hash: ssri::Integrity = "sha256-deadbeef".parse().unwrap();
+    let frame = Frame::builder("nu.mymod").hash(hash).build();
+
+    registry.process_historical(&frame);
+
+    // Registry should have one module entry
+    assert_eq!(registry.modules.len(), 1);
+    assert!(registry.modules.contains_key("mymod"));
+    assert_eq!(registry.modules["mymod"].len(), 1);
+}
+
+#[test]
+fn test_process_historical_ignores_non_nu_frames() {
+    let mut registry = ModuleRegistry::new();
+
+    let hash: ssri::Integrity = "sha256-deadbeef".parse().unwrap();
+    let frame = Frame::builder("other.topic").hash(hash).build();
+
+    registry.process_historical(&frame);
+    assert!(registry.modules.is_empty());
+}
+
+#[test]
+fn test_process_historical_ignores_frames_without_hash() {
+    let mut registry = ModuleRegistry::new();
+
+    let frame = Frame::builder("nu.mymod").build();
+
+    registry.process_historical(&frame);
+    assert!(registry.modules.is_empty());
+}
+
+#[test]
+fn test_process_historical_ignores_bare_nu_prefix() {
+    let mut registry = ModuleRegistry::new();
+
+    let hash: ssri::Integrity = "sha256-deadbeef".parse().unwrap();
+    // "nu." with nothing after should be ignored
+    let frame = Frame::builder("nu.").hash(hash).build();
+
+    registry.process_historical(&frame);
+    assert!(registry.modules.is_empty());
+}
+
+#[test]
+fn test_process_historical_accumulates_versions() {
+    let mut registry = ModuleRegistry::new();
+
+    let hash1: ssri::Integrity = "sha256-aaa".parse().unwrap();
+    let hash2: ssri::Integrity = "sha256-bbb".parse().unwrap();
+
+    let frame1 = Frame::builder("nu.mymod").hash(hash1).build();
+    let frame2 = Frame::builder("nu.mymod").hash(hash2).build();
+
+    registry.process_historical(&frame1);
+    registry.process_historical(&frame2);
+
+    assert_eq!(registry.modules.len(), 1);
+    assert_eq!(registry.modules["mymod"].len(), 2);
+}
+
+#[test]
+fn test_process_historical_dot_separated_name() {
+    let mut registry = ModuleRegistry::new();
+
+    let hash: ssri::Integrity = "sha256-deadbeef".parse().unwrap();
+    let frame = Frame::builder("nu.discord.api").hash(hash).build();
+
+    registry.process_historical(&frame);
+
+    assert_eq!(registry.modules.len(), 1);
+    assert!(registry.modules.contains_key("discord.api"));
+}
+
+// --- Integration tests: VFS registration via dispatcher ---
+
+#[tokio::test]
+async fn test_module_registered_in_vfs() {
+    let (store, _temp_dir) = setup_test_environment().await;
+    let options = ReadOptions::builder().follow(FollowOption::On).build();
+    let mut recver = store.read(options).await;
+
+    assert_eq!(recver.recv().await.unwrap().topic, "xs.threshold");
+
+    // Append a nu module frame
+    let module_content = r#"export def greet [name: string] { $"hello ($name)" }"#;
+    let module_frame = store
+        .append(
+            Frame::builder("nu.testmod")
+                .hash(store.cas_insert(module_content).await.unwrap())
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(recver.recv().await.unwrap().topic, "nu.testmod");
+
+    let module_id = module_frame.id.to_string();
+
+    // Register a handler that uses the module
+    let handler_script = format!(
+        r#"{{
+            run: {{|frame|
+                use xs/{module_id}/testmod
+                testmod greet "world"
+            }}
+        }}"#
+    );
+
+    store
+        .append(
+            Frame::builder("vfstest.register")
+                .hash(store.cas_insert(&handler_script).await.unwrap())
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(recver.recv().await.unwrap().topic, "vfstest.register");
+
+    let next = recver.recv().await.unwrap();
+    if next.topic == "vfstest.unregistered" {
+        let meta = next.meta.as_ref().unwrap();
+        panic!("handler unregistered with error: {}", meta["error"]);
+    }
+    assert_eq!(next.topic, "vfstest.active");
+
+    // Trigger the handler
+    store.append(Frame::builder("ping").build()).unwrap();
+    assert_eq!(recver.recv().await.unwrap().topic, "ping");
+
+    // Handler should output the greeting
+    let out_frame = recver.recv().await.unwrap();
+    assert_eq!(out_frame.topic, "vfstest.out");
+    let content = store.cas_read(&out_frame.hash.unwrap()).await.unwrap();
+    let content_str = std::str::from_utf8(&content).unwrap();
+    assert!(
+        content_str.contains("hello world"),
+        "expected 'hello world' in output, got: {content_str}"
+    );
+
+    assert_no_more_frames(&mut recver).await;
+}
+
+#[tokio::test]
+async fn test_module_dot_path_maps_to_directory() {
+    let (store, _temp_dir) = setup_test_environment().await;
+    let options = ReadOptions::builder().follow(FollowOption::On).build();
+    let mut recver = store.read(options).await;
+
+    assert_eq!(recver.recv().await.unwrap().topic, "xs.threshold");
+
+    // Register a module with dotted name: nu.mylib.utils
+    let module_content = r#"export def add [a: int, b: int] { $a + $b }"#;
+    let module_frame = store
+        .append(
+            Frame::builder("nu.mylib.utils")
+                .hash(store.cas_insert(module_content).await.unwrap())
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(recver.recv().await.unwrap().topic, "nu.mylib.utils");
+
+    let module_id = module_frame.id.to_string();
+
+    // Handler uses xs/mylib/utils/<id> (dots become slashes)
+    let handler_script = format!(
+        r#"{{
+            run: {{|frame|
+                use xs/{module_id}/mylib/utils
+                utils add 3 4
+            }}
+        }}"#
+    );
+
+    store
+        .append(
+            Frame::builder("dotpath.register")
+                .hash(store.cas_insert(&handler_script).await.unwrap())
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(recver.recv().await.unwrap().topic, "dotpath.register");
+    assert_eq!(recver.recv().await.unwrap().topic, "dotpath.active");
+
+    // Trigger
+    store.append(Frame::builder("ping").build()).unwrap();
+    assert_eq!(recver.recv().await.unwrap().topic, "ping");
+
+    let out_frame = recver.recv().await.unwrap();
+    assert_eq!(out_frame.topic, "dotpath.out");
+    let content = store.cas_read(&out_frame.hash.unwrap()).await.unwrap();
+    let content_str = std::str::from_utf8(&content).unwrap();
+    assert!(
+        content_str.contains("7"),
+        "expected '7' in output, got: {content_str}"
+    );
+
+    assert_no_more_frames(&mut recver).await;
+}
+
+#[tokio::test]
+async fn test_live_module_registration() {
+    let (store, _temp_dir) = setup_test_environment().await;
+    let options = ReadOptions::builder().follow(FollowOption::On).build();
+    let mut recver = store.read(options).await;
+
+    assert_eq!(recver.recv().await.unwrap().topic, "xs.threshold");
+
+    // First register a handler that will use a module not yet in VFS.
+    // The module arrives after threshold (live phase), then the handler
+    // registers and should be able to use it.
+
+    // Append module in live phase
+    let module_content = r#"export def double [x: int] { $x * 2 }"#;
+    let module_frame = store
+        .append(
+            Frame::builder("nu.mathlib")
+                .hash(store.cas_insert(module_content).await.unwrap())
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(recver.recv().await.unwrap().topic, "nu.mathlib");
+
+    let module_id = module_frame.id.to_string();
+
+    // Now register a handler that uses the live-registered module
+    let handler_script = format!(
+        r#"{{
+            run: {{|frame|
+                use xs/{module_id}/mathlib
+                mathlib double 21
+            }}
+        }}"#
+    );
+
+    store
+        .append(
+            Frame::builder("livemod.register")
+                .hash(store.cas_insert(&handler_script).await.unwrap())
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(recver.recv().await.unwrap().topic, "livemod.register");
+    assert_eq!(recver.recv().await.unwrap().topic, "livemod.active");
+
+    // Trigger
+    store.append(Frame::builder("ping").build()).unwrap();
+    assert_eq!(recver.recv().await.unwrap().topic, "ping");
+
+    let out_frame = recver.recv().await.unwrap();
+    assert_eq!(out_frame.topic, "livemod.out");
+    let content = store.cas_read(&out_frame.hash.unwrap()).await.unwrap();
+    let content_str = std::str::from_utf8(&content).unwrap();
+    assert!(
+        content_str.contains("42"),
+        "expected '42' in output, got: {content_str}"
+    );
+
+    assert_no_more_frames(&mut recver).await;
+}

--- a/src/nu/test_vfs.rs
+++ b/src/nu/test_vfs.rs
@@ -61,7 +61,7 @@ async fn unit_test_store() -> (Store, tempfile::TempDir) {
 async fn test_process_historical_registers_vfs_paths() {
     let (store, _tmp) = unit_test_store().await;
     let mut engine = nu::Engine::new().unwrap();
-    let mut registry = ModuleRegistry::new();
+    let mut registry = ModuleRegistry;
 
     let content = r#"export def hello [] { "hi" }"#;
     let hash = store.cas_insert(content).await.unwrap();
@@ -77,7 +77,7 @@ async fn test_process_historical_registers_vfs_paths() {
 async fn test_process_historical_ignores_non_nu_frames() {
     let (store, _tmp) = unit_test_store().await;
     let mut engine = nu::Engine::new().unwrap();
-    let mut registry = ModuleRegistry::new();
+    let mut registry = ModuleRegistry;
 
     let hash = store.cas_insert("content").await.unwrap();
     let frame = Frame::builder("other.topic").hash(hash).build();
@@ -90,7 +90,7 @@ async fn test_process_historical_ignores_non_nu_frames() {
 async fn test_process_historical_ignores_frames_without_hash() {
     let (store, _tmp) = unit_test_store().await;
     let mut engine = nu::Engine::new().unwrap();
-    let mut registry = ModuleRegistry::new();
+    let mut registry = ModuleRegistry;
 
     let frame = Frame::builder("mymod.nu").build();
 
@@ -102,7 +102,7 @@ async fn test_process_historical_ignores_frames_without_hash() {
 async fn test_process_historical_ignores_bare_nu_suffix() {
     let (store, _tmp) = unit_test_store().await;
     let mut engine = nu::Engine::new().unwrap();
-    let mut registry = ModuleRegistry::new();
+    let mut registry = ModuleRegistry;
 
     let hash = store.cas_insert("content").await.unwrap();
     // ".nu" with nothing before should be ignored
@@ -116,7 +116,7 @@ async fn test_process_historical_ignores_bare_nu_suffix() {
 async fn test_process_historical_latest_version_shadows() {
     let (store, _tmp) = unit_test_store().await;
     let mut engine = nu::Engine::new().unwrap();
-    let mut registry = ModuleRegistry::new();
+    let mut registry = ModuleRegistry;
 
     let hash1 = store.cas_insert(r#"export def v1 [] { 1 }"#).await.unwrap();
     let hash2 = store.cas_insert(r#"export def v2 [] { 2 }"#).await.unwrap();
@@ -138,7 +138,7 @@ async fn test_process_historical_latest_version_shadows() {
 async fn test_process_historical_dot_separated_name() {
     let (store, _tmp) = unit_test_store().await;
     let mut engine = nu::Engine::new().unwrap();
-    let mut registry = ModuleRegistry::new();
+    let mut registry = ModuleRegistry;
 
     let hash = store
         .cas_insert(r#"export def call [] { "ok" }"#)

--- a/src/nu/vfs.rs
+++ b/src/nu/vfs.rs
@@ -1,0 +1,132 @@
+use std::collections::HashMap;
+
+use nu_protocol::engine::{StateWorkingSet, VirtualPath};
+
+use crate::nu;
+use crate::store::{Frame, Store};
+
+/// Registry that loads nu.* topic frames into the nushell VFS.
+///
+/// Each frame with topic `nu.X.Y.Z` and SCRU128 id `ID` is registered as:
+///   xs/X/Y/Z/ID/mod.nu
+///
+/// This allows handler/generator/command scripts to write:
+///   use xs/X/Y/Z/ID
+#[derive(Default)]
+pub struct ModuleRegistry {
+    /// Accumulated module frames: topic -> list of frames (one per version)
+    modules: HashMap<String, Vec<Frame>>,
+}
+
+impl ModuleRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn process_historical(&mut self, frame: &Frame) {
+        if let Some(name) = frame.topic.strip_prefix("nu.") {
+            if !name.is_empty() && frame.hash.is_some() {
+                self.modules
+                    .entry(name.to_string())
+                    .or_default()
+                    .push(frame.clone());
+            }
+        }
+    }
+
+    pub async fn materialize(
+        &mut self,
+        store: &Store,
+        engine: &mut nu::Engine,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let all_frames: Vec<Frame> = self
+            .modules
+            .values()
+            .flat_map(|frames| frames.iter().cloned())
+            .collect();
+
+        for frame in &all_frames {
+            if let Err(e) = register_module_frame(frame, store, engine).await {
+                tracing::warn!(
+                    "Failed to load module from frame {} ({}): {}",
+                    frame.id,
+                    frame.topic,
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn process_live(
+        &mut self,
+        frame: &Frame,
+        store: &Store,
+        engine: &mut nu::Engine,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(name) = frame.topic.strip_prefix("nu.") {
+            if !name.is_empty() && frame.hash.is_some() {
+                self.modules
+                    .entry(name.to_string())
+                    .or_default()
+                    .push(frame.clone());
+
+                if let Err(e) = register_module_frame(frame, store, engine).await {
+                    tracing::warn!(
+                        "Failed to load module from frame {} ({}): {}",
+                        frame.id,
+                        frame.topic,
+                        e
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Register a single nu.* frame as a virtual module in the engine's VFS.
+///
+/// nu.discord (frame ID 01JAR5...) becomes:
+///   xs/discord/01JAR5.../mod.nu  (virtual file)
+///   xs/discord/01JAR5...         (virtual dir containing mod.nu)
+async fn register_module_frame(
+    frame: &Frame,
+    store: &Store,
+    engine: &mut nu::Engine,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let name = frame
+        .topic
+        .strip_prefix("nu.")
+        .ok_or("frame topic does not start with nu.")?;
+    let hash = frame.hash.as_ref().ok_or("frame has no hash")?;
+
+    let content_bytes = store.cas_read(hash).await?;
+    let content = String::from_utf8(content_bytes)?;
+
+    let id_str = frame.id.to_string();
+    let module_path = name.replace('.', "/");
+
+    let mut working_set = StateWorkingSet::new(&engine.state);
+
+    // Register xs/<module_path>/<scru128>/mod.nu as a virtual file
+    let virt_file_name = format!("xs/{module_path}/{id_str}/mod.nu");
+    let file_id = working_set.add_file(virt_file_name.clone(), content.as_bytes());
+    let virt_file_id = working_set.add_virtual_path(virt_file_name, VirtualPath::File(file_id));
+
+    // Register xs/<module_path>/<scru128> as a virtual dir containing mod.nu
+    let virt_dir_name = format!("xs/{module_path}/{id_str}");
+    let _ = working_set.add_virtual_path(virt_dir_name, VirtualPath::Dir(vec![virt_file_id]));
+
+    engine.state.merge_delta(working_set.render())?;
+
+    tracing::debug!(
+        "Registered VFS module: xs/{}/{} from frame {}",
+        module_path,
+        id_str,
+        frame.id
+    );
+
+    Ok(())
+}

--- a/src/nu/vfs.rs
+++ b/src/nu/vfs.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use nu_protocol::engine::{StateWorkingSet, VirtualPath};
 
 use crate::nu;
@@ -16,10 +14,7 @@ use crate::store::{Frame, Store};
 /// The module name is the last path component (Z). Re-registering a module
 /// at the same path shadows the previous version.
 #[derive(Default)]
-pub struct ModuleRegistry {
-    /// Accumulated module frames: topic -> list of frames (one per version)
-    pub(crate) modules: HashMap<String, Vec<Frame>>,
-}
+pub struct ModuleRegistry;
 
 impl ModuleRegistry {
     pub fn new() -> Self {
@@ -29,11 +24,6 @@ impl ModuleRegistry {
     pub fn process_historical(&mut self, frame: &Frame, engine: &mut nu::Engine, store: &Store) {
         if let Some(name) = frame.topic.strip_suffix(".nu") {
             if !name.is_empty() && frame.hash.is_some() {
-                self.modules
-                    .entry(name.to_string())
-                    .or_default()
-                    .push(frame.clone());
-
                 if let Err(e) = register_module_frame(frame, store, engine) {
                     tracing::warn!(
                         "Failed to load module from frame {} ({}): {}",
@@ -63,11 +53,6 @@ impl ModuleRegistry {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if let Some(name) = frame.topic.strip_suffix(".nu") {
             if !name.is_empty() && frame.hash.is_some() {
-                self.modules
-                    .entry(name.to_string())
-                    .or_default()
-                    .push(frame.clone());
-
                 if let Err(e) = register_module_frame(frame, store, engine) {
                     tracing::warn!(
                         "Failed to load module from frame {} ({}): {}",

--- a/src/nu/vfs.rs
+++ b/src/nu/vfs.rs
@@ -7,14 +7,14 @@ use crate::store::{Frame, Store};
 
 /// Registry that loads *.nu topic frames into the nushell VFS.
 ///
-/// Each frame with topic `X.Y.Z.nu` and SCRU128 id `ID` is registered as:
-///   xs/ID/X/Y/Z/mod.nu
+/// Each frame with topic `X.Y.Z.nu` is registered as:
+///   xs/X/Y/Z/mod.nu
 ///
 /// This allows handler/generator/command scripts to write:
-///   use xs/ID/X/Y/Z
+///   use xs/X/Y/Z
 ///
-/// The module name is the last path component (Z), and the SCRU128 id
-/// pins the exact version.
+/// The module name is the last path component (Z). Re-registering a module
+/// at the same path shadows the previous version.
 #[derive(Default)]
 pub struct ModuleRegistry {
     /// Accumulated module frames: topic -> list of frames (one per version)
@@ -84,18 +84,16 @@ impl ModuleRegistry {
 
 /// Register a single *.nu frame as a virtual module in the engine's VFS.
 ///
-/// testmod.nu (frame ID 01JAR5...) becomes:
-///   xs/01JAR5.../testmod/mod.nu  (virtual file)
-///   xs/01JAR5.../testmod          (virtual dir containing mod.nu)
-///   xs/01JAR5...                  (virtual dir containing testmod/)
+/// testmod.nu becomes:
+///   xs/testmod/mod.nu  (virtual file)
+///   xs/testmod          (virtual dir containing mod.nu)
 ///
-/// discord.api.nu (frame ID 01JAR5...) becomes:
-///   xs/01JAR5.../discord/api/mod.nu
-///   xs/01JAR5.../discord/api      (virtual dir containing mod.nu)
-///   xs/01JAR5.../discord           (virtual dir containing api/)
-///   xs/01JAR5...                   (virtual dir containing discord/)
+/// discord.api.nu becomes:
+///   xs/discord/api/mod.nu
+///   xs/discord/api      (virtual dir containing mod.nu)
+///   xs/discord           (virtual dir containing api/)
 ///
-/// Usage: `use xs/01JAR5.../testmod` imports module named "testmod"
+/// Usage: `use xs/testmod` imports module named "testmod"
 fn register_module_frame(
     frame: &Frame,
     store: &Store,
@@ -110,42 +108,36 @@ fn register_module_frame(
     let content_bytes = store.cas_read_sync(hash)?;
     let content = String::from_utf8(content_bytes)?;
 
-    let id_str = frame.id.to_string();
     let module_path = name.replace('.', "/");
 
     let mut working_set = StateWorkingSet::new(&engine.state);
 
-    // Register xs/<id>/<module_path>/mod.nu as a virtual file
-    let virt_file_name = format!("xs/{id_str}/{module_path}/mod.nu");
+    // Register xs/<module_path>/mod.nu as a virtual file
+    let virt_file_name = format!("xs/{module_path}/mod.nu");
     let file_id = working_set.add_file(virt_file_name.clone(), content.as_bytes());
     let virt_file_id = working_set.add_virtual_path(virt_file_name, VirtualPath::File(file_id));
 
     // Build directory chain from leaf to root:
-    // xs/<id>/<module_path> -> contains mod.nu
-    // xs/<id>/<parent>      -> contains <child>/
+    // xs/<module_path> -> contains mod.nu
+    // xs/<parent>      -> contains <child>/
     // ...
-    // xs/<id>               -> contains <first_segment>/
     let segments: Vec<&str> = module_path.split('/').collect();
     let mut child_id = virt_file_id;
 
     for depth in (0..segments.len()).rev() {
         let dir_path = if depth == 0 {
-            format!("xs/{id_str}/{seg}", seg = segments[0])
+            format!("xs/{seg}", seg = segments[0])
         } else {
             let prefix = segments[..=depth].join("/");
-            format!("xs/{id_str}/{prefix}")
+            format!("xs/{prefix}")
         };
         child_id = working_set.add_virtual_path(dir_path, VirtualPath::Dir(vec![child_id]));
     }
 
-    // Register xs/<id> as root dir containing the first path segment
-    let _ = working_set.add_virtual_path(format!("xs/{id_str}"), VirtualPath::Dir(vec![child_id]));
-
     engine.state.merge_delta(working_set.render())?;
 
     tracing::debug!(
-        "Registered VFS module: xs/{}/{} from frame {}",
-        id_str,
+        "Registered VFS module: xs/{} from frame {}",
         module_path,
         frame.id
     );

--- a/src/nu/vfs.rs
+++ b/src/nu/vfs.rs
@@ -17,10 +17,6 @@ use crate::store::{Frame, Store};
 pub struct ModuleRegistry;
 
 impl ModuleRegistry {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn process_historical(&mut self, frame: &Frame, engine: &mut nu::Engine, store: &Store) {
         if let Some(name) = frame.topic.strip_suffix(".nu") {
             if !name.is_empty() && frame.hash.is_some() {


### PR DESCRIPTION
Removes inline `modules: {}` from handler/generator/command configs. Use `*.nu` topics and VFS `use` imports instead.

## Unified dispatcher

Handlers, generators, and commands each had their own `serve` loop with identical structure: read historical frames, materialize, tail live frames. Now there's one loop in `dispatcher::serve` that delegates to four registries through a shared trait shape (`process_historical` / `materialize` / `process_live`).

## VFS module system

`*.nu` topics register Nushell modules into a virtual filesystem. `mymod.nu` becomes `xs/mymod/mod.nu`; dotted names map to directories (`gpt.ctx.nu` -> `xs/gpt/ctx/mod.nu`). Scripts use standard nushell imports:

```nushell
use xs/mymod
mymod greet "world"
```

Modules are registered eagerly during replay so each handler/generator gets an engine snapshot capturing exactly the modules available at its registration point.

## Other changes

- `parse_config` simplified from two-pass with module extraction to single-pass parse