### PR TITLE
feat: actor closure shape matches nushell generate

### DIFF
--- a/docs/src/content/docs/reference/actors.mdx
+++ b/docs/src/content/docs/reference/actors.mdx
@@ -15,20 +15,24 @@ to process and act on incoming frames as they are appended to the store.
 
 ```nushell
 {
-  run: {|frame|
+  run: {|frame, state|
     if $frame.topic == "ping" {
-      "pong" # Will be appended to actor.out
+      {out: "pong", next: $state}
+    } else {
+      {next: $state}
     }
   }
 }
 ```
 
-The actor closure receives each new frame and can:
+The actor closure receives each new frame and the current state value. It returns a record that controls output and state:
 
-- Process the frame's content
-- Return a value (which gets automatically appended to `<actor-name>.out`)
-- Explicitly append new frames using the `.append` command
-- Filter which frames to process using conditionals
+- `{out: value, next: state}` -- emit `value`, continue with new `state`
+- `{next: state}` -- no output, continue with new `state`
+- `{out: value}` -- emit `value`, then self-terminate
+- `null` / nothing -- self-terminate, no output
+
+The `out` value gets automatically appended to `<actor-name>.out`. The closure can also explicitly append frames using the `.append` command.
 
 ## Registering
 
@@ -38,10 +42,12 @@ actor's behavior:
 
 ```nushell
 r###'{
-  # Required: Actor closure
-  run: {|frame|
+  # Required: Actor closure (frame, state) -> {out?, next?}
+  run: {|frame, state|
     if $frame.topic == "ping" {
-      "pong" # Will be appended to actor.out
+      {out: "pong", next: $state}
+    } else {
+      {next: $state}
     }
   }
 
@@ -60,8 +66,8 @@ r###'{
 }'### | .append echo.register
 ```
 
-The `run` closure must accept **exactly one positional argument** which is the
-incoming frame.
+The `run` closure must accept **exactly two positional arguments**: the incoming
+frame and the current state value.
 
 The registration script is stored in CAS and evaluated to obtain the actor's
 configuration.
@@ -77,7 +83,8 @@ with metadata:
 
 | Field            | Description                                                                |
 | ---------------- | -------------------------------------------------------------------------- |
-| `run`            | Required actor closure that processes each frame                           |
+| `run`            | Required actor closure `{|frame, state| -> {out?, next?}}`                |
+| `initial`        | Initial state value (default: null, or the closure param default)          |
 | `start`          | "new" (default), "first", or scru128 ID to control where processing starts |
 | `pulse`          | Interval in milliseconds to send synthetic xs.pulse events                 |
 | `return_options` | Controls output frames: see Return Options                                 |
@@ -99,40 +106,49 @@ Actors can use modules registered via `*.nu` topics. An actor sees the modules a
 
 ```nushell
 r###'{
-  run: {|frame|
+  run: {|frame, state|
     use xs/my-math
-    my-math double 8
+    {out: (my-math double 8), next: $state}
   }
 }'### | .append processor.register
 ```
 
-## State and Environment
+## State
 
-Actors can maintain state using environment variables which persist between
-calls:
+Actors thread state explicitly through the `next` key in the return record. The
+second closure parameter receives the current state, and `next` sets the state
+for the next invocation:
 
 ```nushell
 r#'{
-  run: {|frame|
-    # Initialize or increment counter
-    let env.count = ($env | get -i count | default 0) + 1
-    $"Processed ($env.count) frames"
+  run: {|frame, state|
+    let count = $state + 1
+    {out: $"Processed ($count) frames", next: $count}
   }
+  initial: 0
 }'# | .append counter.register
 ```
+
+The initial state is resolved in order:
+
+1. The `initial` field in the config record
+2. The default value on the closure's second parameter (e.g. `state = 0`)
+3. `null` if neither is provided
 
 ## Output
 
 Actors can produce output in two ways:
 
-1. **Return Values**: Any non-null return value is automatically appended to the
-   actor's output topic (`<actor-name>.out` by default unless modified by
-   return_options.suffix)
+1. **Return Values**: The `out` key in the return record is automatically
+   appended to the actor's output topic (`<actor-name>.out` by default unless
+   modified by return_options.suffix)
 
 ```nushell
-{|frame|
+{|frame, state|
   if $frame.topic == "ping" {
-    "pong" # Automatically appended to actor.out
+    {out: "pong", next: $state}
+  } else {
+    {next: $state}
   }
 }
 ```
@@ -140,10 +156,13 @@ Actors can produce output in two ways:
 2. **Explicit Appends**: Use the `.append` command to create frames on any topic
 
 ```nushell
-{|frame|
+{|frame, state|
   if $frame.topic == "ping" {
     "pong" | .append response.topic --meta { "type": "response" }
     "logged" | .append audit.topic
+    {next: $state}
+  } else {
+    {next: $state}
   }
 }
 ```
@@ -176,6 +195,7 @@ stateDiagram-v2
         should_run --> [*]: .unregister event
 
         process_event --> [*]: error encountered
+        process_event --> [*]: self-terminated (no next key)
         process_event --> events.recv(): OK
     }
 
@@ -188,6 +208,7 @@ An actor can be unregistered by:
 
 - Appending `<actor-name>.unregister`
 - Registering a new actor with the same name
+- Self-termination: returning `{out: value}`, `{}`, or `null` (no `next` key)
 - Runtime errors in the actor closure
 
 When unregistered, the actor appends a confirmation frame

--- a/docs/src/content/docs/reference/topics.mdx
+++ b/docs/src/content/docs/reference/topics.mdx
@@ -71,9 +71,9 @@ Scripts reference modules by their stable VFS path. Re-appending a module topic 
 
 ```nushell
 r#'{
-  run: {|frame|
+  run: {|frame, state|
     use xs/mymod
-    mymod greet "world"
+    {out: (mymod greet "world"), next: $state}
   }
 }'# | .append greeter.register
 ```

--- a/docs/src/content/docs/tutorials/actor-state.mdx
+++ b/docs/src/content/docs/tutorials/actor-state.mdx
@@ -1,0 +1,202 @@
+---
+title: Actor State
+description: Learn the streaming form of Nushell's generate command, then use the same closure shape to build a stateful actor on cross.stream.
+sidebar:
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import { Link } from '../../../utils/links';
+
+cross.stream actors use the same closure shape as the streaming form of
+Nushell's [`generate`](https://www.nushell.sh/commands/docs/generate.html)
+command. This tutorial teaches that shape in plain Nushell first, then applies
+it on the stream to build a materialized aggregate: a bread and butter of
+stream processing.
+
+<Aside type="note" title="Did you know?">
+The streaming form of `generate`, where input is piped in and the closure
+receives both the element and carried state, was added to Nushell in January
+2025 by [bahex](https://github.com/bahex)
+([nushell#14804](https://github.com/nushell/nushell/pull/14804)).
+</Aside>
+
+## Prerequisites
+
+- <Link to="nu" /> installed
+
+## Part 1: generate with input
+
+When you pipe a stream into `generate`, the closure receives two arguments: the
+current element and the carried state. It returns a record that controls what
+to emit and what state to carry forward.
+
+### Running sum
+
+```nushell
+[3, 1, 4, 1, 5] | generate {|n, sum = 0|
+  let sum = $sum + $n
+  {out: $sum, next: $sum}
+}
+```
+
+```
+ 0 |  3
+ 1 |  4
+ 2 |  8
+ 3 |  9
+ 4 | 14
+```
+
+Each element flows through the closure. `out` is the value emitted downstream.
+`next` is the state passed to the next invocation. The default parameter
+`sum = 0` sets the initial state.
+
+### Skipping output
+
+Not every element needs to produce output. Return `{next: $state}` without an
+`out` key to carry state forward silently:
+
+```nushell
+[1, 2, 3, 4, 5, 6] | generate {|n, sum = 0|
+  let sum = $sum + $n
+  if $n mod 2 == 0 {
+    {out: $"sum at ($n): ($sum)", next: $sum}
+  } else {
+    {next: $sum}
+  }
+}
+```
+
+```
+ 0 | sum at 2: 3
+ 1 | sum at 4: 10
+ 2 | sum at 6: 21
+```
+
+Odd numbers contribute to the sum but produce no output.
+
+### Stopping early
+
+Omit the `next` key (or return nothing) to stop generation:
+
+```nushell
+[1, 2, 3, 4, 5] | generate {|n, sum = 0|
+  let sum = $sum + $n
+  if $sum > 6 {
+    {out: $"stopped at ($sum)"}
+  } else {
+    {out: $sum, next: $sum}
+  }
+}
+```
+
+```
+ 0 |            1
+ 1 |            3
+ 2 |            6
+ 3 | stopped at 10
+```
+
+The final record has `out` but no `next`, so the stream ends.
+
+### The contract
+
+| Return               | Effect                               |
+| -------------------- | ------------------------------------ |
+| `{out: v, next: s}`  | Emit `v`, continue with state `s`    |
+| `{next: s}`          | No output, continue with state `s`   |
+| `{out: v}`           | Emit `v`, then stop                  |
+| nothing              | Stop                                 |
+
+cross.stream actors use this exact contract. Instead of a list, the input stream
+is frames from the store.
+
+## Prerequisites for Part 2
+
+- xs installed and on your PATH (see <Link to="/getting-started/installation/">Installation</Link>)
+- Two terminal windows, both running <Link to="nu" /> with `use xs.nu *`
+
+## Part 2: Running sum on the stream
+
+### Start a store
+
+In terminal 1:
+
+```bash withOutput
+xs serve ./store
+```
+
+### Monitor
+
+In terminal 2, start a live monitor:
+
+```nushell
+.cat -f | each {
+  if $in.hash != null { insert content { .cas $in.hash } } else { } | print ($in | table -e)
+}
+```
+
+Keep this running.
+
+### Register the actor
+
+Same running sum, now as an actor. The closure receives a frame instead of a
+plain number, so it pulls the amount from the frame's metadata:
+
+```nushell
+r#'{
+  run: {|frame, sum = 0|
+    if $frame.topic != "sale" { return {next: $sum} }
+    let sum = $sum + ($frame.meta.amount | into float)
+    {out: $sum, next: $sum}
+  }
+  return_options: { suffix: ".total", ttl: "last:1" }
+}'# | .append revenue.register
+```
+
+The monitor shows `revenue.active`. The actor is live.
+
+### Append some data
+
+```nushell
+.append sale --meta {amount: 49.99}
+.append sale --meta {amount: 12.50}
+.append sale --meta {amount: 7.99}
+```
+
+Three `revenue.total` frames appear. Check the latest:
+
+```bash withOutput
+> .last revenue.total | .cas $in.hash
+70.48
+```
+
+The actor maintains a running total across frames. The `last:1` TTL keeps only
+the most recent total, giving you a materialized view that's always queryable.
+
+### Frames the actor ignores
+
+Append something on a different topic:
+
+```nushell
+.append heartbeat
+```
+
+No `revenue.total` frame appears. The actor returned `{next: $sum}` for the
+non-`sale` frame: state carried forward, no output emitted.
+
+## Recap
+
+| `generate` with input                    | cross.stream actor                           |
+| ---------------------------------------- | -------------------------------------------- |
+| `[data] \| generate {|el, state| ...}`   | Frames flow through `{|frame, state| ...}`   |
+| `{out: v, next: s}` emits downstream     | `out` appended to `<name>.out`               |
+| `{next: s}` skips                        | No frame emitted, state carried forward      |
+| Omit `next` to stop                      | Actor self-terminates, emits `.unregistered`  |
+| Default param sets initial state          | Default param or `initial` config field       |
+
+<Aside type="tip">
+See the <Link to="/reference/actors/">Actors reference</Link> for all
+configuration options including `pulse`, `return_options`, and lifecycle details.
+</Aside>

--- a/docs/src/content/docs/tutorials/mcp-integration.mdx
+++ b/docs/src/content/docs/tutorials/mcp-integration.mdx
@@ -199,12 +199,16 @@ This interactive exploration helps you understand the data structure before writ
 
 ```nushell
 r#'{
-  run: {|frame|
+  run: {|frame, state|
     if ($frame.topic == "mcp.recv") {
       let content = .cas $frame.hash | from json | get -i result.content.0.text
       if ($content != null and "42" in $content) {
-        "meaning of life detected!"
+        {out: "meaning of life detected!", next: $state}
+      } else {
+        {next: $state}
       }
+    } else {
+      {next: $state}
     }
   }
 }'# | .append meaning.detector.register

--- a/examples/discord-bot/README.md
+++ b/examples/discord-bot/README.md
@@ -76,15 +76,15 @@ Add your Discord bot token:
 "<token>" | .append discord.ws.token
 ```
 
-Register heartbeat handler for authentication:
+Register heartbeat actor for authentication:
 
 ```nushell
-open examples/discord-bot/handler-heartbeat.nu | .append "discord.heartbeat.register"
+open examples/discord-bot/actor-heartbeat.nu | .append "discord.heartbeat.register"
 ```
 
 At this point, all messages sent to the Discord server will be available on the
-event stream. You can build from there, creating handlers that take action for
-specific messages. For example, we could register a handler that looks for
+event stream. You can build from there, creating actors that take action for
+specific messages. For example, we could register an actor that looks for
 messages in the form `./roll 1d4` and responds with a dice roll.
 
 Load Discord REST API module:
@@ -93,10 +93,10 @@ Load Discord REST API module:
 http get https://raw.githubusercontent.com/cablehead/discord.nu/main/discord.nu | .append discord.nu
 ```
 
-Register dice roll handler:
+Register dice roll actor:
 
 ```nushell
-open examples/discord-bot/handler-roller.nu | .append "discord.roller.register"
+open examples/discord-bot/actor-roller.nu | .append "discord.roller.register"
 ```
 
 #### Slash commands
@@ -112,6 +112,6 @@ discord app command create 1227338584814649364 dice "make a dice roll" --options
        (discord app command option int modifier "modifier")
    ]
 
-# enable the command handler
-open examples/discord-bot/handler-slash-dice.nu | .append "discord.slash-dice.register"
+# enable the command actor
+open examples/discord-bot/actor-slash-dice.nu | .append "discord.slash-dice.register"
 ```

--- a/examples/discord-bot/actor-bookmarklet.nu
+++ b/examples/discord-bot/actor-bookmarklet.nu
@@ -1,19 +1,19 @@
-{|frame|
-    if $frame.topic != "discord.ws.recv" { return }
+{|frame, state|
+    if $frame.topic != "discord.ws.recv" { return {next: $state} }
 
     let message = ($frame | .cas $in.hash | from json)
-    if $message.op != 0 { return }
+    if $message.op != 0 { return {next: $state} }
 
     match $message.t {
-        "READY" | "GUILD_MEMBER_ADD" => return
+        "READY" | "GUILD_MEMBER_ADD" => { return {next: $state} }
 
         "MESSAGE_CREATE" | "MESSAGE_DELETE" | "MESSAGE_UPDATE" => {
             .append $"message.($message.d.id)" --meta {id: $frame.id}
-            return
+            return {next: $state}
         }
 
         "MESSAGE_REACTION_ADD" => {
-            if $message.d.emoji.name != "🔖" { return }
+            if $message.d.emoji.name != "🔖" { return {next: $state} }
 
             let bookmarks = (
                 .last "bookmarks" | if ($in | is-not-empty)  {
@@ -22,11 +22,11 @@
 
             $bookmarks | upsert $message.d.message_id true |
                 to json -r | .append "bookmarks" --meta {id: $frame.id}
-            return
+            return {next: $state}
         }
 
         "MESSAGE_REACTION_REMOVE" => {
-            if $message.d.emoji.name != "🔖" { return }
+            if $message.d.emoji.name != "🔖" { return {next: $state} }
 
             let bookmarks = (
                 .last "bookmarks" | if ($in | is-not-empty)  {
@@ -35,9 +35,9 @@
 
             $bookmarks | reject -i $message.d.message_id |
                 to json -r | .append "bookmarks" --meta {id: $frame.id}
-            return
+            return {next: $state}
         }
     }
 
-    return $message
+    {out: $message, next: $state}
 }

--- a/examples/discord-bot/actor-heartbeat.nu
+++ b/examples/discord-bot/actor-heartbeat.nu
@@ -57,7 +57,13 @@ def .send [] {
     to json -r | $"($in)\n" | .append "discord.ws.send" --ttl head:5
 }
 
-$env.state = {
+$env.BOT_TOKEN = .last discord.ws.token | .cas $in.hash
+
+{
+  start: (.last discord.ws.running | get -i id | default "first")
+  pulse: 1000
+
+  initial: {
     s: null,
     heartbeat_interval: 0,
     last_sent: null,
@@ -67,43 +73,34 @@ $env.state = {
     resume_gateway_url: null
   }
 
-$env.BOT_TOKEN = .last discord.ws.token | .cas $in.hash
-
-{
-  start: (.last discord.ws.running | get -i id | default "first")
-  pulse: 1000
-
-  run: {|frame|
+  run: {|frame, state|
     # https://discord.com/developers/docs/topics/gateway#list-of-intents
     # GUILDS, GUILD_MEMBERS, GUILD_MESSAGES, GUILD_MESSAGE_REACTIONS, MESSAGE_CONTENT
     let IDENTIFY_INTENTS = 34307
 
     if $frame.topic == "xs.pulse" {
         # we're not online
-        if $env.state.heartbeat_interval == 0 {
-            return
+        if $state.heartbeat_interval == 0 {
+            return {next: $state}
         }
 
         # online, but not authed, attempt to auth
-        if (($env.state.heartbeat_interval != 0) and ($env.state.authing | is-empty)) {
+        if (($state.heartbeat_interval != 0) and ($state.authing | is-empty)) {
             op identify $env.BOT_TOKEN $IDENTIFY_INTENTS | .send
-            $env.state.authing = "identify"
-            return
+            return {next: ($state | merge {authing: "identify"})}
         }
 
-        let since = (scru128-since $frame.id $env.state.last_sent)
-        let interval = (($env.state.heartbeat_interval * 0.9) * 1ms)
+        let since = (scru128-since $frame.id $state.last_sent)
+        let interval = (($state.heartbeat_interval * 0.9) * 1ms)
         if ($since > $interval) {
             op heartbeat | .send
-            $env.state.last_ack = null
-            $env.state.last_sent = $frame.id
-            return
+            return {next: ($state | merge {last_ack: null, last_sent: $frame.id})}
         }
-        return
+        return {next: $state}
     }
 
     if $frame.topic != "discord.ws.recv" {
-        return
+        return {next: $state}
     }
 
     let message = $frame | .cas $in.hash | from json
@@ -111,21 +108,23 @@ $env.BOT_TOKEN = .last discord.ws.token | .cas $in.hash
     match $message {
         # hello
         {op: 10} => {
-            $env.state.heartbeat_interval = $message.d.heartbeat_interval
-            $env.state.last_ack = $frame.id
-            $env.state.last_sent = $frame.id
-            $env.state.authing = null
+            {next: ($state | merge {
+                heartbeat_interval: $message.d.heartbeat_interval,
+                last_ack: $frame.id,
+                last_sent: $frame.id,
+                authing: null
+            })}
         }
 
         # heartbeat_ack
         {op: 11} => {
-            $env.state.last_ack = $frame.id
             .rm $frame.id
+            {next: ($state | merge {last_ack: $frame.id})}
         }
 
         # resume
         {op: 6} => {
-            $env.state.authing = "resume"
+            {next: ($state | merge {authing: "resume"})}
         }
 
         # invalid_session
@@ -133,28 +132,39 @@ $env.BOT_TOKEN = .last discord.ws.token | .cas $in.hash
             # The inner d key is a boolean that indicates whether the session may be resumable.
             # if we get an invalid session while trying to resume, also clear
             # out the session
-            if not $message.d or $env.state.authing == "resume" {
-                $env.state.resume_gateway_url = null
-                $env.state.session_id = null
+            if not $message.d or $state.authing == "resume" {
+                {next: ($state | merge {
+                    resume_gateway_url: null,
+                    session_id: null,
+                    authing: null
+                })}
+            } else {
+                {next: ($state | merge {authing: null})}
             }
-            $env.state.authing = null
         }
 
         # dispatch:: READY
         {op: 0, t: "READY"} => {
-            $env.state.session_id = $message.d.session_id
-            $env.state.resume_gateway_url = $message.d.resume_gateway_url
-            $env.state.authing = "authed"
+            {next: ($state | merge {
+                session_id: $message.d.session_id,
+                resume_gateway_url: $message.d.resume_gateway_url,
+                authing: "authed"
+            })}
         }
 
         # dispatch:: RESUMED
         {op: 0, t: "RESUMED"} => {
-            $env.state.authing = "authed"
+            {next: ($state | merge {authing: "authed"})}
         }
 
         # dispatch:: GUILD_CREATE
         {op: 0, t: "GUILD_CREATE"} => {
             # ignore
+            {next: $state}
+        }
+
+        _ => {
+            {next: $state}
         }
     }
   }

--- a/examples/discord-bot/actor-heartbeat.nu
+++ b/examples/discord-bot/actor-heartbeat.nu
@@ -54,7 +54,7 @@ def "scru128-since" [$id1, $id2] {
 }
 
 def .send [] {
-    to json -r | $"($in)\n" | .append "discord.ws.send" --ttl head:5
+    to json -r | $"($in)\n" | .append "discord.ws.send" --ttl last:5
 }
 
 $env.BOT_TOKEN = .last discord.ws.token | .cas $in.hash

--- a/examples/discord-bot/actor-roller.nu
+++ b/examples/discord-bot/actor-roller.nu
@@ -32,15 +32,15 @@ def run-roll [] {
 $env.BOT_TOKEN = .last discord.ws.token | .cas $in.hash
 
 {
-  run: {|frame|
+  run: {|frame, state|
     use xs/discord
-    if $frame.topic != "discord.ws.recv" { return }
+    if $frame.topic != "discord.ws.recv" { return {next: $state} }
 
     # TODO: .cas should also be able to take a record, to match xs2.nu's usage
     let message = $frame | .cas $in.hash | from json
 
-    if $message.op != 0 { return }
-    if $message.t != "MESSAGE_CREATE" { return }
+    if $message.op != 0 { return {next: $state} }
+    if $message.t != "MESSAGE_CREATE" { return {next: $state} }
 
     $message.d.content | parse-roller | & {
       {
@@ -48,5 +48,7 @@ $env.BOT_TOKEN = .last discord.ws.token | .cas $in.hash
         message_reference: { message_id: $message.d.id }
       } | discord channel message create $message.d.channel_id
     }
+
+    {next: $state}
   }
 }

--- a/examples/discord-bot/actor-slash-dice.nu
+++ b/examples/discord-bot/actor-slash-dice.nu
@@ -33,15 +33,15 @@ def run-dice [options: record] {
    $content
 }
 
-{|frame|
-    if $frame.topic != "discord.ws.recv" { return }
+{|frame, state|
+    if $frame.topic != "discord.ws.recv" { return {next: $state} }
 
     let message = $frame | .cas $in.hash | from json
-    if $message.op != 0 { return }
-    if $message.t != "INTERACTION_CREATE" { return }
+    if $message.op != 0 { return {next: $state} }
+    if $message.t != "INTERACTION_CREATE" { return {next: $state} }
 
     let command = $message.d.data
-    if $command.name != "dice" { return }
+    if $command.name != "dice" { return {next: $state} }
 
     let options = (
         $command.options |
@@ -52,4 +52,5 @@ def run-dice [options: record] {
     let content = run-dice $options
 
     $message.d | interaction response $in.id $in.token $content
+    {next: $state}
 }

--- a/src/nu/test_vfs.rs
+++ b/src/nu/test_vfs.rs
@@ -194,9 +194,9 @@ async fn test_module_registered_in_vfs() {
 
     // Register an actor that uses the module
     let actor_script = r#"{
-            run: {|frame|
+            run: {|frame, state = null|
                 use xs/testmod
-                testmod greet "world"
+                {out: (testmod greet "world"), next: $state}
             }
         }"#;
 
@@ -256,9 +256,9 @@ async fn test_module_dot_path_maps_to_directory() {
 
     // Actor uses xs/mylib/utils (dots become slashes)
     let actor_script = r#"{
-            run: {|frame|
+            run: {|frame, state = null|
                 use xs/mylib/utils
-                utils add 3 4
+                {out: (utils add 3 4), next: $state}
             }
         }"#;
 
@@ -311,9 +311,9 @@ async fn test_live_module_registration() {
 
     // Now register an actor that uses the live-registered module
     let actor_script = r#"{
-            run: {|frame|
+            run: {|frame, state = null|
                 use xs/mathlib
-                mathlib double 21
+                {out: (mathlib double 21), next: $state}
             }
         }"#;
 

--- a/src/processor/action/serve.rs
+++ b/src/processor/action/serve.rs
@@ -186,7 +186,7 @@ fn run_action(
     let mut engine_clone = engine.clone();
     engine_clone.run_closure_in_job(
         &closure,
-        Some(arg_val),
+        vec![arg_val],
         None,
         format!("action {topic}", topic = frame.topic),
     )

--- a/src/processor/service/service.rs
+++ b/src/processor/service/service.rs
@@ -458,7 +458,7 @@ fn spawn_thread(
     std::thread::spawn(move || {
         let res = match task.engine.run_closure_in_job(
             &task.run_closure,
-            None,
+            vec![],
             Some(input_pipeline),
             task.id.to_string(),
         ) {


### PR DESCRIPTION
Actor closures change from `{|frame| -> any}` with `$env.state` mutation to `{|frame, state| -> {out?, next?}}`, matching nushell's `generate` streaming closure shape.

State is threaded explicitly through the return record. No `next` key means self-terminate. Initial state resolves from config `initial` field, closure param default, or null.

`run_closure_in_job` now takes `args: Vec<Value>` instead of `arg: Option<Value>`.

Discord-bot example files renamed from `handler-*` to `actor-*` and converted to the new shape.