### PR TITLE
Allow custom RelayMode via XS_RELAY_URL env var

### DIFF
--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -1,5 +1,6 @@
 use crate::listener::{AsyncReadWriteBox, IrohStream, ALPN, HANDSHAKE};
-use iroh::{Endpoint, RelayMode, SecretKey};
+use crate::relay::relay_mode_from_env;
+use iroh::{Endpoint, SecretKey};
 use iroh_base::ticket::NodeTicket;
 use rustls::pki_types::ServerName;
 use rustls::ClientConfig;
@@ -71,7 +72,7 @@ pub async fn connect(parts: &RequestParts) -> Result<AsyncReadWriteBox, BoxError
             // Create an iroh endpoint for connecting
             let endpoint = Endpoint::builder()
                 .alpns(vec![])
-                .relay_mode(RelayMode::Default)
+                .relay_mode(relay_mode_from_env())
                 .secret_key(secret_key)
                 .bind()
                 .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod listener;
 pub mod nu;
 pub mod processor;
+pub mod relay;
 pub mod scru128;
 pub mod store;
 pub mod trace;

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -3,8 +3,10 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use iroh::endpoint::{RecvStream, SendStream};
-use iroh::{Endpoint, RelayMode, SecretKey, Watcher};
+use iroh::{Endpoint, SecretKey, Watcher};
 use iroh_base::ticket::NodeTicket;
+
+use crate::relay::relay_mode_from_env;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpListener;
 
@@ -300,7 +302,7 @@ impl Listener {
             let secret_key = get_or_create_secret()?;
             let endpoint = Endpoint::builder()
                 .alpns(vec![ALPN.to_vec()])
-                .relay_mode(RelayMode::Default)
+                .relay_mode(relay_mode_from_env())
                 .secret_key(secret_key)
                 .bind()
                 .await
@@ -371,7 +373,7 @@ impl Listener {
                 // Create a client endpoint
                 let client_endpoint = Endpoint::builder()
                     .alpns(vec![])
-                    .relay_mode(RelayMode::Default)
+                    .relay_mode(relay_mode_from_env())
                     .secret_key(secret_key)
                     .bind()
                     .await

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -1,0 +1,121 @@
+//! Resolves the [`iroh::RelayMode`] from an `XS_RELAY_URL` environment variable.
+//!
+//! xs's iroh endpoints (both server-side in [`crate::listener`] and client-side
+//! in [`crate::client::connect`]) historically hardcoded [`RelayMode::Default`],
+//! which routes via n0's public relay infrastructure. That's the right default,
+//! but operators have legitimate reasons to override:
+//!
+//! - **Regions where n0's defaults aren't reachable.** The Asia-Pacific
+//!   regional relay (`apse-1.relay.iroh.network`) currently has no public DNS
+//!   A record, so iroh nodes in that region hang on
+//!   `home_relay().initialized().await`. Operators self-host a relay in the
+//!   region and point xs at it.
+//! - **Compliance / air-gapped networks** where outbound to relay.iroh.network
+//!   isn't permitted.
+//! - **Local testing** with a self-hosted dev relay.
+//!
+//! Setting `XS_RELAY_URL=https://my-relay.example.com` makes both the listener
+//! and the connect path use [`RelayMode::Custom`] with that single relay.
+//! Setting `XS_RELAY_URL=disabled` selects [`RelayMode::Disabled`] (no relay at
+//! all — works only when peers are directly reachable, e.g. on a LAN/VPC).
+//! Empty/unset preserves the existing [`RelayMode::Default`] behavior so this
+//! patch is a strict superset.
+
+use iroh::{RelayMap, RelayMode};
+use iroh_base::RelayUrl;
+
+/// The env var consulted by [`relay_mode_from_env`].
+pub const ENV_VAR: &str = "XS_RELAY_URL";
+
+/// Resolves the relay configuration from the [`ENV_VAR`] env var.
+///
+/// - Empty or unset → [`RelayMode::Default`] (n0 public relays — the existing default).
+/// - `"disabled"` (case-insensitive) → [`RelayMode::Disabled`].
+/// - Otherwise treated as a relay URL → [`RelayMode::Custom`] with a single-entry [`RelayMap`].
+///   If the URL fails to parse, logs a warning and falls back to [`RelayMode::Default`]
+///   so a typo doesn't break otherwise-working setups.
+pub fn relay_mode_from_env() -> RelayMode {
+    let raw = std::env::var(ENV_VAR).unwrap_or_default();
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return RelayMode::Default;
+    }
+    if trimmed.eq_ignore_ascii_case("disabled") {
+        tracing::info!("{ENV_VAR}=disabled — using RelayMode::Disabled");
+        return RelayMode::Disabled;
+    }
+    match trimmed.parse::<RelayUrl>() {
+        Ok(url) => {
+            tracing::info!("{ENV_VAR}={trimmed} — using RelayMode::Custom");
+            RelayMode::Custom(RelayMap::from(url))
+        }
+        Err(err) => {
+            tracing::warn!(
+                "{ENV_VAR}={trimmed} failed to parse as RelayUrl ({err}); falling back to RelayMode::Default"
+            );
+            RelayMode::Default
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests temporarily set env vars; serialise them to avoid cross-test races.
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        static M: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        M.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn unset_returns_default() {
+        let _g = lock();
+        // SAFETY: under the test mutex, no concurrent env access.
+        unsafe { std::env::remove_var(ENV_VAR) };
+        assert_eq!(relay_mode_from_env(), RelayMode::Default);
+    }
+
+    #[test]
+    fn empty_returns_default() {
+        let _g = lock();
+        unsafe { std::env::set_var(ENV_VAR, "") };
+        assert_eq!(relay_mode_from_env(), RelayMode::Default);
+        unsafe { std::env::remove_var(ENV_VAR) };
+    }
+
+    #[test]
+    fn whitespace_returns_default() {
+        let _g = lock();
+        unsafe { std::env::set_var(ENV_VAR, "   ") };
+        assert_eq!(relay_mode_from_env(), RelayMode::Default);
+        unsafe { std::env::remove_var(ENV_VAR) };
+    }
+
+    #[test]
+    fn disabled_keyword_returns_disabled() {
+        let _g = lock();
+        unsafe { std::env::set_var(ENV_VAR, "DISABLED") };
+        assert_eq!(relay_mode_from_env(), RelayMode::Disabled);
+        unsafe { std::env::remove_var(ENV_VAR) };
+    }
+
+    #[test]
+    fn valid_url_returns_custom() {
+        let _g = lock();
+        unsafe { std::env::set_var(ENV_VAR, "https://relay.example.com") };
+        match relay_mode_from_env() {
+            RelayMode::Custom(map) => assert_eq!(map.len(), 1),
+            other => panic!("expected RelayMode::Custom, got {other:?}"),
+        }
+        unsafe { std::env::remove_var(ENV_VAR) };
+    }
+
+    #[test]
+    fn malformed_url_falls_back_to_default() {
+        let _g = lock();
+        unsafe { std::env::set_var(ENV_VAR, "not a url") };
+        assert_eq!(relay_mode_from_env(), RelayMode::Default);
+        unsafe { std::env::remove_var(ENV_VAR) };
+    }
+}


### PR DESCRIPTION
## Why

`xs` currently hardcodes `iroh::RelayMode::Default` in three places (`listener.rs:303`, `listener.rs:374`, `client/connect.rs:74`). `RelayMode::Default` routes via n0's public relay infrastructure (`use1`, `euw1`, `apse-1`).

That's the right default, but operators have legitimate reasons to override:

- **Regions where n0's defaults aren't reachable.** As of writing, `apse-1.relay.iroh.network` has no public DNS A record. Iroh nodes in Asia hang indefinitely on `home_relay().initialized().await` — a laptop in Thailand cannot bind an `iroh://` endpoint at all. Self-hosting an `iroh-relay` (e.g. on a Hetzner Singapore VM) is the workaround, but today it requires source-patching `xs`.
- **Compliance / air-gapped networks** where outbound to `relay.iroh.network` isn't permitted.
- **Local development** against a self-hosted dev relay.

## What

Introduces `src/relay.rs` exporting `relay_mode_from_env() -> RelayMode`:

| `XS_RELAY_URL` value | resolves to |
|---|---|
| empty / unset | `RelayMode::Default` (preserves existing behavior — strict superset) |
| `"disabled"` (case-insensitive) | `RelayMode::Disabled` |
| any other value | parsed as `iroh_base::RelayUrl` → `RelayMode::Custom(RelayMap)` |
| parse failure | falls back to `RelayMode::Default` with a `tracing::warn!` |

The three iroh endpoint builders in `listener.rs` and `client/connect.rs` now call this helper instead of using the hardcoded constant.

## Backward compatibility

Strict superset. Users who don't set `XS_RELAY_URL` get exactly the prior behavior.

## Tests

6 unit tests in `src/relay::tests` cover: unset, empty, whitespace, `"DISABLED"` keyword, valid URL → `Custom`, malformed URL → `Default` fallback.

All existing tests pass (`cargo test --lib`).

## Verification

Built locally and run from a Thai laptop against a self-hosted `iroh-relay 1.0.0-rc.0` on Hetzner Singapore (5.223.94.174 in `--dev` mode):

```
XS_RELAY_URL=http://5.223.94.174:3340 ./target/release/xs serve /tmp/store --expose iroh://

09:54:38.859  INFO XS_RELAY_URL=http://5.223.94.174:3340 — using RelayMode::Custom
09:54:38.888 DEBUG Iroh endpoint bound successfully
09:54:41.892  INFO Iroh endpoint ready with node ID: f19a07801049…
09:54:41.892  INFO Iroh ticket: nodeadyzub4ac…
```

Without the patch, the bind hangs forever in that environment.

## Naming alternative

Happy to rename the env var (e.g. `XS_RELAY` or `CROSSTREAM_RELAY_URL`) if there's a project convention I should follow.