### PR TITLE
fix: prepared engine fixes .append on restart and inside modules

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -74,12 +74,20 @@ jobs:
       - name: Pre-pull Dagger Engine
         run: docker pull registry.dagger.io/engine:v0.18.14
 
-      # 7) Run one Dagger build function and export artifact
+      # 7) Run one Dagger build function and export artifact.
+      # Retried: the builder image is pulled inside Dagger, so a transient
+      # Docker Hub outage (e.g. 504 from auth.docker.io) is not primed away by
+      # the engine pre-pull above. The CLI was installed by Setup Dagger.
       - name: Build with Dagger
-        uses: dagger/dagger-for-github@8.0.0
-        with:
-          version: "0.18.14"
-          call: ${{ matrix.dagger_fn }} --src upload --src . --version ${{ steps.version.outputs.version }} export --path ./artifacts/${{ steps.version.outputs.artifact }}
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            dagger call ${{ matrix.dagger_fn }} --src upload --src . --version ${{ steps.version.outputs.version }} export --path ./artifacts/${{ steps.version.outputs.artifact }} && exit 0
+            echo "::warning::Dagger build attempt ${attempt} failed; retrying in 20s"
+            sleep 20
+          done
+          echo "::error::Dagger build failed after 3 attempts"
+          exit 1
 
       # 8) Upload artifact for fan-in job
       - name: Upload artifact

--- a/docs/adr/0006-store-builtins-on-prepared-engine.md
+++ b/docs/adr/0006-store-builtins-on-prepared-engine.md
@@ -1,0 +1,30 @@
+# 0006: Store builtins on a prepared, cloneable engine
+
+Each runner kind (eval, service, action, actor) builds one prepared base engine and clones it per spawn. No runner re-registers builtins after the base exists.
+
+## Base
+
+`nu::prepared_base(store, read, direct_write)` = nushell + stdlib + core commands + `.rm` alias + the read surface, plus `.append` for direct writers. `build_engine` is gone. Per use, the caller clones the base, applies `load_modules(as_of)`, and sets per-instance state.
+
+| runner  | read   | write                              |
+|---------|--------|------------------------------------|
+| eval    | Stream | Direct `.append` on the base       |
+| service | Stream | Direct `.append` on the base       |
+| action  | Stream | Direct `.append` on the base       |
+| actor   | Plain  | Buffered `.append` added per clone |
+
+The actor's buffered `.append` is per-instance (it batches an actor's appends to commit atomically with the output frame), so it stays off the shared base.
+
+## .append metadata
+
+`.append`'s base metadata is instance-independent: it comes from the `XS_APPEND_META` env var (a JSON object string), read at run time, not from the command constructor. The runner sets it per instance via `Engine::set_append_meta`:
+
+- service: `{service_id}`
+- action: `{action_id, frame_id}` (per triggering frame)
+- eval: unset, so the base is empty
+
+`.append --meta {..}` merges over the env base; an absent or malformed env resolves to an empty base.
+
+## Why
+
+Baking metadata into the decl forced every spawn to re-register `.append`, and the service hot-replace path forgot to, so a re-registered service hit `.append command not found`. With the surface on a cloned base and metadata in `$env`, a hot-replace clones a pristine engine and cannot lose `.append`.

--- a/docs/adr/0006-store-builtins-on-prepared-engine.md
+++ b/docs/adr/0006-store-builtins-on-prepared-engine.md
@@ -13,7 +13,14 @@ Each runner kind (eval, service, action, actor) builds one prepared base engine 
 | action  | Stream | Direct `.append` on the base       |
 | actor   | Plain  | Buffered `.append` added per clone |
 
-The actor's buffered `.append` is per-instance (it batches an actor's appends to commit atomically with the output frame), so it stays off the shared base.
+## Append modes
+
+`AppendMode` is the one part of the surface that varies by runner:
+
+- **Direct** -- each `.append` writes its frame straight to the store as the call runs. Used by eval, service, and action. The decl carries no per-instance state, so it lives on the shared base.
+- **Buffered** -- `.append` collects frames into a per-instance buffer instead of writing; the actor flushes that buffer so an actor's appends land atomically alongside its output frame. The buffer is per-instance, so this `.append` is added to each clone, not the base.
+
+Both modes share the same `.append` signature and the `XS_APPEND_META` base metadata below; they differ only in where the frame goes.
 
 ## .append metadata
 

--- a/docs/adr/0006-store-builtins-on-prepared-engine.md
+++ b/docs/adr/0006-store-builtins-on-prepared-engine.md
@@ -4,7 +4,7 @@ Each runner kind (eval, service, action, actor) builds one prepared base engine 
 
 ## Base
 
-`nu::prepared_base(store, read, direct_write)` = nushell + stdlib + core commands + `.rm` alias + the read surface, plus `.append` for direct writers. `build_engine` is gone. Per use, the caller clones the base, applies `load_modules(as_of)`, and sets per-instance state.
+`nu::prepared_base(store, read, direct_write)` = nushell + stdlib + the core builtins + `.rm` alias + the read builtins, plus `.append` for direct writers. `build_engine` is gone. Per use, the caller clones the base, applies `load_modules(as_of)`, and sets per-instance state.
 
 | runner  | read   | write                              |
 |---------|--------|------------------------------------|
@@ -15,7 +15,7 @@ Each runner kind (eval, service, action, actor) builds one prepared base engine 
 
 ## Append modes
 
-`AppendMode` is the one part of the surface that varies by runner:
+`AppendMode` is the one builtin whose behaviour varies by runner:
 
 - **Direct** -- each `.append` writes its frame straight to the store as the call runs. Used by eval, service, and action. The decl carries no per-instance state, so it lives on the shared base.
 - **Buffered** -- `.append` collects frames into a per-instance buffer instead of writing; the actor flushes that buffer so an actor's appends land atomically alongside its output frame. The buffer is per-instance, so this `.append` is added to each clone, not the base.
@@ -34,4 +34,4 @@ Both modes share the same `.append` signature and the `XS_APPEND_META` base meta
 
 ## Why
 
-Baking metadata into the decl forced every spawn to re-register `.append`, and the service hot-replace path forgot to, so a re-registered service hit `.append command not found`. With the surface on a cloned base and metadata in `$env`, a hot-replace clones a pristine engine and cannot lose `.append`.
+Baking metadata into the decl forced every spawn to re-register `.append`, and the service hot-replace path forgot to, so a re-registered service hit `.append command not found`. With the builtins on a cloned base and metadata in `$env`, a hot-replace clones a pristine engine and cannot lose `.append`.

--- a/src/api.rs
+++ b/src/api.rs
@@ -650,12 +650,8 @@ async fn handle_eval(store: &Store, body: hyper::body::Incoming) -> HTTPResult {
     // Add the read/append surface (streaming reads, direct append)
     nu::add_read_commands(&mut engine, store, nu::ReadMode::Stream)
         .map_err(|e| format!("Failed to add read commands to engine: {e}"))?;
-    nu::add_write_commands(
-        &mut engine,
-        store,
-        nu::AppendMode::Direct(serde_json::Value::Null),
-    )
-    .map_err(|e| format!("Failed to add write commands to engine: {e}"))?;
+    nu::add_write_commands(&mut engine, store, nu::AppendMode::Direct)
+        .map_err(|e| format!("Failed to add write commands to engine: {e}"))?;
 
     // Execute the script
     let result = engine
@@ -926,7 +922,6 @@ mod tests {
                 ),
                 Box::new(crate::nu::commands::append_command::AppendCommand::new(
                     store.clone(),
-                    serde_json::Value::Null,
                 )),
             ])
             .unwrap();

--- a/src/api.rs
+++ b/src/api.rs
@@ -633,16 +633,27 @@ fn empty() -> BoxBody<Bytes, BoxError> {
         .boxed()
 }
 
+/// Engine for an ad-hoc `.eval` script: the prepared base (Stream reads +
+/// Direct `.append`) plus the VFS modules registered so far, so eval scripts
+/// can `use` them, the same surface the runners get.
+fn eval_engine(store: &Store) -> Result<nu::Engine, String> {
+    let mut engine = nu::prepared_base(store, nu::ReadMode::Stream, true)
+        .map_err(|e| format!("Failed to build nushell engine: {e}"))?;
+    // Modules registered up to now: a fresh time-ordered id exceeds every
+    // already-appended frame.
+    let modules = store.nu_modules_at(&scru128::new());
+    nu::load_modules(&mut engine.state, store, &modules)
+        .map_err(|e| format!("Failed to load modules: {e}"))?;
+    Ok(engine)
+}
+
 async fn handle_eval(store: &Store, body: hyper::body::Incoming) -> HTTPResult {
     // Read the script from the request body
     let bytes = body.collect().await?.to_bytes();
     let script =
         String::from_utf8(bytes.to_vec()).map_err(|e| format!("Invalid UTF-8 in script: {e}"))?;
 
-    // Create nushell engine with store helper commands
-    // Same prepared surface as the runners (Stream reads + Direct `.append`).
-    let engine = nu::prepared_base(store, nu::ReadMode::Stream, true)
-        .map_err(|e| format!("Failed to build nushell engine: {e}"))?;
+    let engine = eval_engine(store)?;
 
     // Execute the script
     let result = engine
@@ -941,5 +952,33 @@ mod tests {
             }
             _ => panic!("Expected Int Value, got {:?}", result),
         }
+    }
+
+    // An `.eval` script must be able to `use` a registered VFS module.
+    #[tokio::test]
+    async fn test_eval_uses_modules() {
+        use crate::store::{Frame, Store};
+        use nu_protocol::PipelineData;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_path_buf()).unwrap();
+
+        let hash = store
+            .cas_insert_sync(r#"export def add_nums [x, y] { $"sum is ($x + $y)" }"#)
+            .unwrap();
+        store
+            .append(Frame::builder("xs.module.mymod").hash(hash).build())
+            .unwrap();
+
+        let engine = super::eval_engine(&store).unwrap();
+        let result = engine
+            .eval(
+                PipelineData::empty(),
+                "use mymod; mymod add_nums 40 2".to_string(),
+            )
+            .unwrap()
+            .into_value(nu_protocol::Span::test_data())
+            .unwrap();
+        assert_eq!(result.into_string().unwrap(), "sum is 42");
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -635,7 +635,7 @@ fn empty() -> BoxBody<Bytes, BoxError> {
 
 /// Engine for an ad-hoc `.eval` script: the prepared base (Stream reads +
 /// Direct `.append`) plus the VFS modules registered so far, so eval scripts
-/// can `use` them, the same surface the runners get.
+/// can `use` them, the same builtins the runners get.
 fn eval_engine(store: &Store) -> Result<nu::Engine, String> {
     let mut engine = nu::prepared_base(store, nu::ReadMode::Stream, true)
         .map_err(|e| format!("Failed to build nushell engine: {e}"))?;

--- a/src/api.rs
+++ b/src/api.rs
@@ -981,4 +981,38 @@ mod tests {
             .unwrap();
         assert_eq!(result.into_string().unwrap(), "sum is 42");
     }
+
+    // A module's exported function must be able to call the store builtins (here
+    // `.append`), not just pure nushell. (rokf94's report; the engine carries
+    // the builtins before modules load.)
+    #[tokio::test]
+    async fn test_module_can_use_append_builtin() {
+        use crate::store::{Frame, Store};
+        use nu_protocol::{PipelineData, Span};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_path_buf()).unwrap();
+
+        let hash = store
+            .cas_insert_sync(r#"export def emit [] { {} | .append out --meta {via: "module"} }"#)
+            .unwrap();
+        store
+            .append(Frame::builder("xs.module.emitter").hash(hash).build())
+            .unwrap();
+
+        let engine = super::eval_engine(&store).unwrap();
+        let value = engine
+            .eval(
+                PipelineData::empty(),
+                "use emitter; emitter emit".to_string(),
+            )
+            .unwrap()
+            .into_value(Span::test_data())
+            .unwrap();
+
+        // `.append` ran inside the module and returned the appended frame.
+        let json = crate::nu::value_to_json(&value);
+        assert_eq!(json["topic"], "out");
+        assert_eq!(json["meta"]["via"], "module");
+    }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -640,18 +640,9 @@ async fn handle_eval(store: &Store, body: hyper::body::Incoming) -> HTTPResult {
         String::from_utf8(bytes.to_vec()).map_err(|e| format!("Invalid UTF-8 in script: {e}"))?;
 
     // Create nushell engine with store helper commands
-    let mut engine =
-        nu::Engine::new().map_err(|e| format!("Failed to create nushell engine: {e}"))?;
-
-    // Add core commands
-    nu::add_core_commands(&mut engine, store)
-        .map_err(|e| format!("Failed to add core commands to engine: {e}"))?;
-
-    // Add the read/append surface (streaming reads, direct append)
-    nu::add_read_commands(&mut engine, store, nu::ReadMode::Stream)
-        .map_err(|e| format!("Failed to add read commands to engine: {e}"))?;
-    nu::add_write_commands(&mut engine, store, nu::AppendMode::Direct)
-        .map_err(|e| format!("Failed to add write commands to engine: {e}"))?;
+    // Same prepared surface as the runners (Stream reads + Direct `.append`).
+    let engine = nu::prepared_base(store, nu::ReadMode::Stream, true)
+        .map_err(|e| format!("Failed to build nushell engine: {e}"))?;
 
     // Execute the script
     let result = engine

--- a/src/nu/commands/append_command.rs
+++ b/src/nu/commands/append_command.rs
@@ -7,15 +7,20 @@ use serde_json::Value as JsonValue;
 use crate::nu::util;
 use crate::store::{Frame, Store, TTL};
 
+/// Env var carrying the base metadata stamped on every frame a runner appends
+/// (`service_id`, `{action_id, frame_id}`, ...), as a JSON object string.
+/// Injecting it per instance keeps `.append` instance-independent, so one decl
+/// can be registered on a prepared engine and reused across spawns and restarts.
+pub const APPEND_META_ENV: &str = "XS_APPEND_META";
+
 #[derive(Clone)]
 pub struct AppendCommand {
     store: Store,
-    base_meta: JsonValue,
 }
 
 impl AppendCommand {
-    pub fn new(store: Store, base_meta: JsonValue) -> Self {
-        Self { store, base_meta }
+    pub fn new(store: Store) -> Self {
+        Self { store }
     }
 }
 
@@ -66,18 +71,24 @@ impl Command for AppendCommand {
 
         let topic: String = call.req(engine_state, stack, 0)?;
 
-        // Get user-supplied metadata and convert to JSON
-        let user_meta: Option<Value> = call.get_flag(engine_state, stack, "meta")?;
-        let mut final_meta = self.base_meta.clone(); // Start with base metadata
+        // Base metadata is injected per instance via $env; absent or malformed
+        // resolves to an empty object.
+        let mut base_obj = stack
+            .get_env_var(engine_state, APPEND_META_ENV)
+            .and_then(|v| v.coerce_string().ok())
+            .and_then(|s| serde_json::from_str::<JsonValue>(&s).ok())
+            .and_then(|j| match j {
+                JsonValue::Object(m) => Some(m),
+                _ => None,
+            })
+            .unwrap_or_default();
 
-        // Merge user metadata if provided
+        // Merge user-supplied metadata on top of the base.
+        let user_meta: Option<Value> = call.get_flag(engine_state, stack, "meta")?;
         if let Some(user_value) = user_meta {
-            let user_json = util::value_to_json(&user_value);
-            if let JsonValue::Object(mut base_obj) = final_meta {
-                if let JsonValue::Object(user_obj) = user_json {
-                    base_obj.extend(user_obj); // Merge user metadata into base
-                    final_meta = JsonValue::Object(base_obj);
-                } else {
+            match util::value_to_json(&user_value) {
+                JsonValue::Object(user_obj) => base_obj.extend(user_obj),
+                _ => {
                     return Err(ShellError::TypeMismatch {
                         err_message: "Meta must be a record".to_string(),
                         span: call.span(),
@@ -85,6 +96,7 @@ impl Command for AppendCommand {
                 }
             }
         }
+        let final_meta = JsonValue::Object(base_obj);
 
         let ttl: Option<String> = call.get_flag(engine_state, stack, "ttl")?;
         let ttl = match ttl {

--- a/src/nu/engine.rs
+++ b/src/nu/engine.rs
@@ -180,6 +180,16 @@ impl Engine {
         Ok(self)
     }
 
+    /// Set the base metadata stamped on frames this engine's `.append` writes
+    /// (`service_id`, `{action_id, frame_id}`, ...). Injected as `$env` so the
+    /// `.append` decl stays instance-independent. See `append_command`.
+    pub fn set_append_meta(&mut self, meta: &JsonValue) {
+        self.state.add_env_var(
+            crate::nu::commands::append_command::APPEND_META_ENV.to_string(),
+            Value::string(meta.to_string(), Span::unknown()),
+        );
+    }
+
     pub fn run_closure_in_job(
         &mut self,
         closure: &nu_protocol::engine::Closure,
@@ -325,8 +335,9 @@ pub enum ReadMode {
 /// How `.append` behaves. This is the one axis of the store surface that
 /// genuinely varies by runner.
 pub enum AppendMode {
-    /// Write straight to the store, tagging each frame's metadata with `base_meta`.
-    Direct(JsonValue),
+    /// Write straight to the store. The per-instance base metadata is injected
+    /// via the `XS_APPEND_META` env var (see `append_command`), not baked in.
+    Direct,
     /// Buffer appended frames into `output` for the caller to flush (actors).
     Buffered(Arc<Mutex<Vec<Frame>>>),
 }
@@ -363,11 +374,28 @@ pub fn add_write_commands(
         )),
     ])?;
     match mode {
-        AppendMode::Direct(base_meta) => engine.add_commands(vec![Box::new(
-            commands::append_command::AppendCommand::new(store.clone(), base_meta),
+        AppendMode::Direct => engine.add_commands(vec![Box::new(
+            commands::append_command::AppendCommand::new(store.clone()),
         )]),
         AppendMode::Buffered(output) => engine.add_commands(vec![Box::new(
             commands::append_command_buffered::AppendCommand::new(store.clone(), output),
         )]),
     }
+}
+
+/// The module-free, instance-free base engine for a runner: nushell + stdlib +
+/// core commands + the `.rm` alias + the read surface, plus the `.append` write
+/// surface for direct writers. Build this once per runner and `clone()` it per
+/// spawn or restart; `load_modules(as_of)` and `set_append_meta(..)` specialize
+/// each clone. Actors pass `direct_write: false` and add their per-instance
+/// buffered `.append` to the clone.
+pub fn prepared_base(store: &Store, read: ReadMode, direct_write: bool) -> Result<Engine, Error> {
+    let mut engine = Engine::new()?;
+    add_core_commands(&mut engine, store)?;
+    engine.add_alias(".rm", ".remove")?;
+    add_read_commands(&mut engine, store, read)?;
+    if direct_write {
+        add_write_commands(&mut engine, store, AppendMode::Direct)?;
+    }
+    Ok(engine)
 }

--- a/src/nu/engine.rs
+++ b/src/nu/engine.rs
@@ -332,7 +332,7 @@ pub enum ReadMode {
     Plain,
 }
 
-/// How `.append` behaves. This is the one axis of the store surface that
+/// How `.append` behaves. This is the one store command whose behaviour
 /// genuinely varies by runner.
 pub enum AppendMode {
     /// Write straight to the store. The per-instance base metadata is injected
@@ -342,7 +342,7 @@ pub enum AppendMode {
     Buffered(Arc<Mutex<Vec<Frame>>>),
 }
 
-/// Register the `.cat` and `.last` read commands for a pipeline runner.
+/// Register the `.cat` and `.last` read builtins for a pipeline runner.
 pub fn add_read_commands(engine: &mut Engine, store: &Store, mode: ReadMode) -> Result<(), Error> {
     match mode {
         ReadMode::Stream => engine.add_commands(vec![
@@ -360,8 +360,8 @@ pub fn add_read_commands(engine: &mut Engine, store: &Store, mode: ReadMode) -> 
     }
 }
 
-/// Register the write surface for a pipeline runner: `.append` (per `mode`) plus
-/// `.import` and `.cas-post`, which are identical across runners.
+/// Register the write builtins for a pipeline runner: `.append` (per `mode`)
+/// plus `.import` and `.cas-post`, which are identical across runners.
 pub fn add_write_commands(
     engine: &mut Engine,
     store: &Store,
@@ -384,8 +384,8 @@ pub fn add_write_commands(
 }
 
 /// The module-free, instance-free base engine for a runner: nushell + stdlib +
-/// core commands + the `.rm` alias + the read surface, plus the `.append` write
-/// surface for direct writers. Build this once per runner and `clone()` it per
+/// the core builtins + the `.rm` alias + the read builtins, plus the `.append`
+/// write builtin for direct writers. Build this once per runner and `clone()` it per
 /// spawn or restart; `load_modules(as_of)` and `set_append_meta(..)` specialize
 /// each clone. Actors pass `direct_write: false` and add their per-instance
 /// buffered `.append` to the clone.

--- a/src/nu/mod.rs
+++ b/src/nu/mod.rs
@@ -6,7 +6,8 @@ pub mod commands;
 pub mod util;
 pub use config::{parse_config, NuScriptConfig, ReturnOptions};
 pub use engine::{
-    add_core_commands, add_read_commands, add_write_commands, AppendMode, Engine, ReadMode,
+    add_core_commands, add_read_commands, add_write_commands, prepared_base, AppendMode, Engine,
+    ReadMode,
 };
 pub use util::{frame_to_pipeline, frame_to_value, value_to_json};
 pub use vfs::load_modules;

--- a/src/nu/test_commands.rs
+++ b/src/nu/test_commands.rs
@@ -49,12 +49,10 @@ mod tests {
     #[test]
     fn test_append_command() {
         let (store, mut engine) = setup_test_env();
+        engine.set_append_meta(&json!({"base": "meta"}));
         engine
             .add_commands(vec![Box::new(
-                commands::append_command::AppendCommand::new(
-                    store.clone(),
-                    json!({"base": "meta"}),
-                ),
+                commands::append_command::AppendCommand::new(store.clone()),
             )])
             .unwrap();
 

--- a/src/nu/test_commands.rs
+++ b/src/nu/test_commands.rs
@@ -97,6 +97,39 @@ mod tests {
         assert!(frame.hash.is_none());
     }
 
+    // `.append` takes its base metadata from the `XS_APPEND_META` env var at run
+    // time, so the decl is instance-independent and a prepared engine can be
+    // cloned per runner.
+    #[test]
+    fn test_append_meta_from_env() {
+        let (store, mut engine) = setup_test_env();
+        engine
+            .add_commands(vec![Box::new(
+                commands::append_command::AppendCommand::new(store.clone()),
+            )])
+            .unwrap();
+
+        // No env, no --meta: base is an empty object.
+        let frame = value_to_frame(nu_eval(&engine, PipelineData::empty(), r#".append a"#));
+        assert_eq!(frame.meta.unwrap(), json!({}));
+
+        // Base comes from $env.XS_APPEND_META, read at run time.
+        let frame = value_to_frame(nu_eval(
+            &engine,
+            PipelineData::empty(),
+            r#"$env.XS_APPEND_META = '{"service_id": "svc"}'; .append b"#,
+        ));
+        assert_eq!(frame.meta.unwrap(), json!({"service_id": "svc"}));
+
+        // User --meta merges over the env base.
+        let frame = value_to_frame(nu_eval(
+            &engine,
+            PipelineData::empty(),
+            r#"$env.XS_APPEND_META = '{"service_id": "svc"}'; .append c --meta {k: 1}"#,
+        ));
+        assert_eq!(frame.meta.unwrap(), json!({"service_id": "svc", "k": 1}));
+    }
+
     #[test]
     fn test_cas_command_string() {
         let (store, mut engine) = setup_test_env();

--- a/src/processor/action/serve.rs
+++ b/src/processor/action/serve.rs
@@ -53,12 +53,12 @@ async fn register_action(frame: &Frame, store: &Store) -> Result<Action, Error> 
     let definition_bytes = store.cas_read(hash).await?;
     let definition = String::from_utf8(definition_bytes)?;
 
-    // Build engine from scratch with VFS modules at this point in the stream
-    let mut engine = crate::processor::build_engine(store, &frame.id)?;
-
-    // Actions read with the streaming variants; .append is added per-invocation
-    // in execute_action, since its base_meta depends on the triggering frame.
-    nu::add_read_commands(&mut engine, store, nu::ReadMode::Stream)?;
+    // Prepared base (Stream reads + Direct `.append`), then the VFS modules as
+    // of this frame. The per-invocation engine is a clone of this, so it only
+    // needs `set_append_meta` for the triggering frame.
+    let mut engine = nu::prepared_base(store, nu::ReadMode::Stream, true)?;
+    let modules = store.nu_modules_at(&frame.id);
+    nu::load_modules(&mut engine.state, store, &modules)?;
 
     // Parse the action configuration
     let nu_config = nu::parse_config(&mut engine, &definition)?;
@@ -96,7 +96,7 @@ async fn execute_action(action: Action, frame: &Frame, store: &Store) -> Result<
     tokio::task::spawn_blocking(move || {
         let mut engine = action.engine;
 
-        nu::add_write_commands(&mut engine, &store, nu::AppendMode::Direct)?;
+        // The base already carries `.append`; only the per-frame meta varies.
         engine.set_append_meta(&serde_json::json!({
             "action_id": action.id.to_string(),
             "frame_id": frame.id.to_string()

--- a/src/processor/action/serve.rs
+++ b/src/processor/action/serve.rs
@@ -94,14 +94,13 @@ async fn execute_action(action: Action, frame: &Frame, store: &Store) -> Result<
     let frame = frame.clone();
 
     tokio::task::spawn_blocking(move || {
-        let base_meta = serde_json::json!({
-            "action_id": action.id.to_string(),
-            "frame_id": frame.id.to_string()
-        });
-
         let mut engine = action.engine;
 
-        nu::add_write_commands(&mut engine, &store, nu::AppendMode::Direct(base_meta))?;
+        nu::add_write_commands(&mut engine, &store, nu::AppendMode::Direct)?;
+        engine.set_append_meta(&serde_json::json!({
+            "action_id": action.id.to_string(),
+            "frame_id": frame.id.to_string()
+        }));
 
         // Parse the action configuration to get the up-to-date closure with modules loaded
         let nu_config = nu::parse_config(&mut engine, &action.definition)?;

--- a/src/processor/actor/actor.rs
+++ b/src/processor/actor/actor.rs
@@ -76,7 +76,8 @@ impl Actor {
         store: Store,
     ) -> Result<Self, Error> {
         let output = Arc::new(Mutex::new(Vec::new()));
-        nu::add_read_commands(&mut engine, &store, nu::ReadMode::Plain)?;
+        // Reads come from the prepared base; only the per-instance buffered
+        // `.append` (for atomic batch commit) is added here.
         nu::add_write_commands(
             &mut engine,
             &store,
@@ -360,8 +361,11 @@ impl Actor {
             .await
             .map_err(|e| format!("Failed to read expression: {e}"))?;
 
-        // Build engine from scratch with VFS modules at this point in the stream
-        let engine = crate::processor::build_engine(store, &frame.id)?;
+        // Prepared base (Plain reads); the actor's per-instance buffered
+        // `.append` is added in Actor::new. Modules as of this frame.
+        let mut engine = nu::prepared_base(store, nu::ReadMode::Plain, false)?;
+        let modules = store.nu_modules_at(&frame.id);
+        nu::load_modules(&mut engine.state, store, &modules)?;
 
         let actor = Actor::new(
             frame.id,

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -3,22 +3,8 @@ pub mod actor;
 pub mod lifecycle;
 pub mod service;
 
-use crate::nu;
-use crate::store::{Frame, Store};
-use scru128::Scru128Id;
+use crate::store::Frame;
 use tokio::sync::mpsc;
-
-pub fn build_engine(
-    store: &Store,
-    as_of: &Scru128Id,
-) -> Result<nu::Engine, Box<dyn std::error::Error + Send + Sync>> {
-    let mut engine = nu::Engine::new()?;
-    nu::add_core_commands(&mut engine, store)?;
-    engine.add_alias(".rm", ".remove")?;
-    let modules = store.nu_modules_at(as_of);
-    nu::load_modules(&mut engine.state, store, &modules)?;
-    Ok(engine)
-}
 
 pub enum Lifecycle {
     Historical(Frame),

--- a/src/processor/service/service.rs
+++ b/src/processor/service/service.rs
@@ -180,25 +180,33 @@ pub fn spawn(store: Store, spawn_frame: Frame) -> JoinHandle<()> {
     tokio::spawn(async move { run(store, spawn_frame).await })
 }
 
+/// Clone the prepared base engine and specialize it for a `<name>.create`
+/// frame: load the modules visible as of that frame and stamp `service_id`.
+/// The read/append command surface already lives on `base`, so neither the
+/// initial spawn nor a hot-replace re-registers builtins.
+fn specialize(
+    base: &nu::Engine,
+    store: &Store,
+    create_id: Scru128Id,
+) -> Result<nu::Engine, Box<dyn std::error::Error + Send + Sync>> {
+    let mut engine = base.clone();
+    let modules = store.nu_modules_at(&create_id);
+    nu::load_modules(&mut engine.state, store, &modules)?;
+    engine.set_append_meta(&serde_json::json!({ "service_id": create_id.to_string() }));
+    Ok(engine)
+}
+
 async fn run(store: Store, spawn_frame: Frame) {
-    let mut engine = match crate::processor::build_engine(&store, &spawn_frame.id) {
+    // Prepared once (nushell + stdlib + core + Stream reads + Direct `.append`);
+    // cloned for the initial run and every hot-replace.
+    let base = match nu::prepared_base(&store, nu::ReadMode::Stream, true) {
         Ok(e) => e,
         Err(_) => return,
     };
-
-    // Services get the same read/append surface as the other runners. Their
-    // appends are tagged with the spawning frame's id as `service_id`.
-    let base_meta = serde_json::json!({ "service_id": spawn_frame.id.to_string() });
-    if crate::nu::add_read_commands(&mut engine, &store, crate::nu::ReadMode::Stream).is_err()
-        || crate::nu::add_write_commands(
-            &mut engine,
-            &store,
-            crate::nu::AppendMode::Direct(base_meta),
-        )
-        .is_err()
-    {
-        return;
-    }
+    let mut engine = match specialize(&base, &store, spawn_frame.id) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
 
     let hash = match spawn_frame.hash.clone() {
         Some(h) => h,
@@ -252,10 +260,10 @@ async fn run(store: Store, spawn_frame: Frame) {
         engine,
     };
 
-    run_loop(store, loop_ctx, task).await;
+    run_loop(store, loop_ctx, task, base).await;
 }
 
-async fn run_loop(store: Store, loop_ctx: ServiceLoop, mut task: Task) {
+async fn run_loop(store: Store, loop_ctx: ServiceLoop, mut task: Task, base: nu::Engine) {
     // Create the first start frame and set up a persistent control subscription
     let start_event = emit_event(
         &store,
@@ -353,7 +361,10 @@ async fn run_loop(store: Store, loop_ctx: ServiceLoop, mut task: Task) {
                                 if let Ok(mut reader) = store.cas_reader(hash).await {
                                     let mut script = String::new();
                                     if reader.read_to_string(&mut script).await.is_ok() {
-                                        let mut new_engine = match crate::processor::build_engine(&store, &frame.id) {
+                                        // Clone the prepared base; the read/append surface is
+                                        // already on it, so a hot-replace never re-registers
+                                        // builtins.
+                                        let mut new_engine = match specialize(&base, &store, frame.id) {
                                             Ok(e) => e,
                                             Err(_) => continue,
                                         };

--- a/src/processor/service/service.rs
+++ b/src/processor/service/service.rs
@@ -182,7 +182,7 @@ pub fn spawn(store: Store, spawn_frame: Frame) -> JoinHandle<()> {
 
 /// Clone the prepared base engine and specialize it for a `<name>.create`
 /// frame: load the modules visible as of that frame and stamp `service_id`.
-/// The read/append command surface already lives on `base`, so neither the
+/// The read and write builtins already live on `base`, so neither the
 /// initial spawn nor a hot-replace re-registers builtins.
 fn specialize(
     base: &nu::Engine,
@@ -361,8 +361,8 @@ async fn run_loop(store: Store, loop_ctx: ServiceLoop, mut task: Task, base: nu:
                                 if let Ok(mut reader) = store.cas_reader(hash).await {
                                     let mut script = String::new();
                                     if reader.read_to_string(&mut script).await.is_ok() {
-                                        // Clone the prepared base; the read/append surface is
-                                        // already on it, so a hot-replace never re-registers
+                                        // Clone the prepared base; the read and write builtins
+                                        // are already on it, so a hot-replace never re-registers
                                         // builtins.
                                         let mut new_engine = match specialize(&base, &store, frame.id) {
                                             Ok(e) => e,

--- a/src/processor/service/tests.rs
+++ b/src/processor/service/tests.rs
@@ -1452,3 +1452,144 @@ async fn test_service_activates_alongside_other_processors() {
         "service stuck at .create -- never reached .active with actor+service+action co-hosted"
     );
 }
+
+// Regression: a hot-replaced service (a second `xs.service.<name>.create`)
+// must keep the read/append command surface. The initial spawn registers
+// `.append`/`.cat`/`.last`, but the hot-replace path rebuilt the engine
+// without them, so a re-registered service's run closure failed with
+// "command not found" on `.append`. First registration worked, the second did
+// not.
+#[tokio::test]
+async fn test_serve_append_survives_hot_replace() {
+    let store = setup_test_env();
+
+    {
+        let store = store.clone();
+        drop(tokio::spawn(async move {
+            crate::processor::service::run(store).await.unwrap();
+        }));
+    }
+
+    let options = ReadOptions::builder()
+        .follow(FollowOption::On)
+        .new(true)
+        .build();
+    let mut recver = store.read(options).await;
+
+    // First registration appends `ping` with gen=1.
+    let script1 = r#"{ run: {|| sleep 100ms; {} | .append ping --meta {gen: 1} } }"#;
+    store
+        .append(
+            Frame::builder("xs.service.pinger.create")
+                .maybe_hash(store.cas_insert(script1).await.ok())
+                .build(),
+        )
+        .unwrap();
+
+    let gen_of = |f: &Frame| -> Option<u64> {
+        f.meta
+            .as_ref()
+            .and_then(|m| m.get("gen"))
+            .and_then(|v| v.as_u64())
+    };
+
+    // Wait for a gen=1 ping: the first registration works.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut saw_gen1 = false;
+    while Instant::now() < deadline && !saw_gen1 {
+        if let Ok(Some(f)) = tokio::time::timeout(Duration::from_secs(5), recver.recv()).await {
+            if f.topic == "ping" && gen_of(&f) == Some(1) {
+                saw_gen1 = true;
+            }
+        }
+    }
+    assert!(saw_gen1, "first registration never appended a ping");
+
+    // Hot-replace with a second .create whose run closure also appends.
+    let script2 = r#"{ run: {|| sleep 100ms; {} | .append ping --meta {gen: 2} } }"#;
+    store
+        .append(
+            Frame::builder("xs.service.pinger.create")
+                .maybe_hash(store.cas_insert(script2).await.ok())
+                .build(),
+        )
+        .unwrap();
+
+    // The hot-replaced service must still have `.append`: expect a gen=2 ping,
+    // and never an .invalid / .fin.error.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut saw_gen2 = false;
+    while Instant::now() < deadline && !saw_gen2 {
+        match tokio::time::timeout(Duration::from_secs(5), recver.recv()).await {
+            Ok(Some(f)) if f.topic == "ping" && gen_of(&f) == Some(2) => {
+                saw_gen2 = true;
+            }
+            Ok(Some(f))
+                if f.topic == "xs.service.pinger.fin.error"
+                    || f.topic == "xs.service.pinger.invalid" =>
+            {
+                panic!(
+                    "hot-replaced service lost its command surface: {} meta={:?}",
+                    f.topic, f.meta
+                );
+            }
+            _ => continue,
+        }
+    }
+
+    assert!(
+        saw_gen2,
+        "hot-replaced service never appended a ping; `.append` was likely missing after re-registration"
+    );
+}
+
+// Locks the service write surface's instance metadata: a frame a service
+// appends via `.append` carries `service_id` (the spawn frame's id) as base
+// meta, with any user `--meta` merged on top.
+#[tokio::test]
+async fn test_serve_append_tags_service_id() {
+    let store = setup_test_env();
+
+    {
+        let store = store.clone();
+        drop(tokio::spawn(async move {
+            crate::processor::service::run(store).await.unwrap();
+        }));
+    }
+
+    let script = r#"{ run: {|| sleep 100ms; {} | .append out --meta {k: "v"} } }"#;
+    let frame_service = store
+        .append(
+            Frame::builder("xs.service.tagger.create")
+                .maybe_hash(store.cas_insert(script).await.ok())
+                .build(),
+        )
+        .unwrap();
+
+    let options = ReadOptions::builder()
+        .follow(FollowOption::On)
+        .new(true)
+        .build();
+    let mut recver = store.read(options).await;
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut checked = false;
+    while Instant::now() < deadline && !checked {
+        if let Ok(Some(f)) = tokio::time::timeout(Duration::from_secs(5), recver.recv()).await {
+            if f.topic == "out" {
+                let meta = f
+                    .meta
+                    .as_ref()
+                    .expect("appended `out` frame should carry meta");
+                assert_eq!(meta["service_id"], frame_service.id.to_string());
+                assert_eq!(meta["k"], "v");
+                checked = true;
+            }
+        }
+    }
+
+    assert!(
+        checked,
+        "service never appended an `out` frame to assert on"
+    );
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,6 +11,28 @@ use tokio::time::timeout;
 
 use xs::store::Frame;
 
+/// Wait until the supervisor's socket exists and the server actually accepts a
+/// connection. Polling a real `xs cat` (instead of a fixed sleep after the sock
+/// file appears) closes a Windows AF_UNIX race where the sock file is created
+/// before the listener accepts, which surfaced as `os error 10061`.
+async fn wait_until_ready(store_path: &std::path::Path) {
+    let start = std::time::Instant::now();
+    loop {
+        let ready = store_path.join("sock").exists()
+            && cmd!(assert_cmd::cargo::cargo_bin!("xs"), "cat", store_path)
+                .stderr_null()
+                .read()
+                .is_ok();
+        if ready {
+            return;
+        }
+        if start.elapsed() > Duration::from_secs(15) {
+            panic!("Timeout waiting for xs server to accept connections");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
 #[tokio::test]
 async fn test_integration() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -18,15 +40,7 @@ async fn test_integration() {
 
     let mut child = spawn_xs_supervisor(store_path).await;
 
-    let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until_ready(store_path).await;
 
     // Verify xs.start frame
     let output = cmd!(assert_cmd::cargo::cargo_bin!("xs"), "cat", store_path)
@@ -114,15 +128,7 @@ async fn test_cat_sse_format() {
 
     let mut child = spawn_xs_supervisor(store_path).await;
 
-    let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until_ready(store_path).await;
 
     // Append test data
     cmd!(
@@ -160,15 +166,7 @@ async fn test_eval_integration() {
 
     let mut child = spawn_xs_supervisor(store_path).await;
 
-    let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until_ready(store_path).await;
 
     // Test simple string expression
     let output = cmd!(
@@ -297,15 +295,7 @@ async fn test_eval_streaming_behavior() {
 
     let mut supervisor = spawn_xs_supervisor(store_path).await;
 
-    let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until_ready(store_path).await;
 
     // Pipeline that outputs "immediate" right away, then "end" after 1 second
     let script =
@@ -357,15 +347,7 @@ async fn test_eval_bytestream_behavior() {
 
     let mut supervisor = spawn_xs_supervisor(store_path).await;
 
-    let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until_ready(store_path).await;
 
     // Test that binary data passes through without JSON encoding
     // Create a temp file with binary content, then open it to get a ByteStream
@@ -407,15 +389,7 @@ async fn test_eval_cat_streaming() {
 
     let mut child = spawn_xs_supervisor(store_path).await;
 
-    let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until_ready(store_path).await;
 
     // Append initial test data
     cmd!(
@@ -575,15 +549,7 @@ async fn test_eval_last_follow() {
 
     let mut child = spawn_xs_supervisor(store_path).await;
 
-    let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until_ready(store_path).await;
 
     // Append initial test data
     cmd!(
@@ -668,15 +634,7 @@ async fn test_last_wildcard_topic() {
 
     let mut child = spawn_xs_supervisor(store_path).await;
 
-    let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until_ready(store_path).await;
 
     // Append frames to multiple topics under W.*
     cmd!(
@@ -729,15 +687,8 @@ async fn test_xs_last_cli() {
 
     let mut child = spawn_xs_supervisor(store_path).await;
 
+    wait_until_ready(store_path).await;
     let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Append frames to different topics
     for (topic, content) in [
@@ -977,15 +928,7 @@ async fn test_eval_ls_outputs_plain_json() {
 
     let mut child = spawn_xs_supervisor(store_path).await;
 
-    let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until_ready(store_path).await;
 
     let output = cmd!(
         assert_cmd::cargo::cargo_bin!("xs"),
@@ -1177,15 +1120,7 @@ async fn test_sqlite_commands_available() {
 
     let mut child = spawn_xs_supervisor(store_path).await;
 
-    let sock_path = store_path.join("sock");
-    let start = std::time::Instant::now();
-    while !sock_path.exists() {
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Timeout waiting for sock file");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until_ready(store_path).await;
 
     let db_path = temp_dir.path().join("test.db");
     // Use forward slashes for cross-platform nushell compatibility


### PR DESCRIPTION
## What

Every nushell runner now builds its engine the same way, and two `.append` bugs are fixed along the way.

Before, four places (service, action, actor, eval) each hand-rolled the same setup: build an engine, then register the read and `.append` builtins. Two problems fell out of that:

1. The service restart path forgot the re-registration, so a re-registered service hit `.append command not found` on its second run.
2. Modules loaded before the builtins were present, so a module's exported function could not call `.append` (rokf94's report; ndyg confirmed it an oversight).

## Changes

- `.append`'s base metadata (`service_id`, `{action_id, frame_id}`) now comes from `$env` instead of the command's constructor. The decl is instance-independent, so a prepared engine can be cloned per use.
- New `nu::prepared_base(store, read, direct_write)`: nushell + stdlib + core builtins + the read builtins, plus `.append` for direct writers. Built once, cloned per spawn.
- Service builds the base once and clones it for the initial spawn and every hot-replace. Restart no longer re-registers builtins, so it cannot lose `.append`.
- Action registers its write builtins once at register, not per call. Actor keeps its per-instance buffered `.append` (atomic batch commit). Eval shares the base and now loads VFS modules, so `.eval` scripts can `use` them.
- Because the builtins are on the engine before modules load, a module's exported function can now call `.append` and the other store builtins.
- `build_engine` deleted; it had no callers left.

## Tests

- `test_serve_append_survives_hot_replace`: a re-registered service keeps `.append`.
- `test_serve_append_tags_service_id`: a service's appends carry `service_id`.
- `test_append_meta_from_env`: `.append` reads its base meta from `XS_APPEND_META`.
- `test_eval_uses_modules`: an `.eval` script can `use` a registered module.
- `test_module_can_use_append_builtin`: a module's function can call `.append`.
- Full suite green; `check.sh` clean.

## ADR

`docs/adr/0006-store-builtins-on-prepared-engine.md`.
