### PR TITLE
feat: let a Store carry a base engine that processor engines clone

### DIFF
--- a/docs/adr/0007-engine-tree.md
+++ b/docs/adr/0007-engine-tree.md
@@ -1,0 +1,28 @@
+# 0007: Engine tree
+
+xs runs Nushell in two places: the one-shot evaluator and the actor, service, and action processors. Both build their engine from `nu::prepared_base`, a base engine plus the store commands, cloned per spawn.
+
+## Prepare once, clone per use
+
+A subsystem that builds engines repeatedly prepares its base once and clones it per spawn, rather than rebuilding from scratch each time.
+
+## The base
+
+`prepared_base` starts from a base engine and adds the store commands (core, read, and the per-runner write). The base defaults to `Engine::new()`: the nu context, the standard library, and the environment.
+
+## An embedder can supply the base
+
+A program that embeds xs can supply the base via `Store::with_base_engine`, so its own commands reach the processors. `prepared_base` clones the supplied base per spawn and adds the store commands on top; with no base set it uses `Engine::new()`.
+
+The `prepared_base_carries_store_base_engine_commands` test stands in for an embedder: it puts an `xs-base-marker` command on the base and asserts a processor engine resolves it.
+
+```mermaid
+flowchart TD
+    Base["embedder base via with_base_engine: Engine::new() + xs-base-marker"]
+    Base --> Eval["one-shot eval: xs-base-marker"]
+    Base --> Proc["actor / service / action processors: xs-base-marker + store commands"]
+```
+
+## Relation to ADR 0006
+
+[ADR 0006](0006-store-builtins-on-prepared-engine.md) established the prepared, cloneable base and the store-command layering. This ADR lets an embedder supply that base's non-store portion.

--- a/src/nu/engine.rs
+++ b/src/nu/engine.rs
@@ -489,7 +489,16 @@ pub fn add_write_commands(
 /// each clone. Actors pass `direct_write: false` and add their per-instance
 /// buffered `.append` to the clone.
 pub fn prepared_base(store: &Store, read: ReadMode, direct_write: bool) -> Result<Engine, Error> {
-    let mut engine = Engine::new()?;
+    // Clone the embedder-provided base (its context-free commands, env, and
+    // consts) when one is set, so every processor engine branches from it;
+    // otherwise build the default base. See the "Engine tree" note: prepare the
+    // base once, clone per use.
+    let mut engine = match store.base_engine() {
+        Some(base) => Engine {
+            state: base.clone(),
+        },
+        None => Engine::new()?,
+    };
     add_core_commands(&mut engine, store)?;
     engine.add_alias(".rm", ".remove")?;
     add_read_commands(&mut engine, store, read)?;

--- a/src/nu/engine.rs
+++ b/src/nu/engine.rs
@@ -489,10 +489,8 @@ pub fn add_write_commands(
 /// each clone. Actors pass `direct_write: false` and add their per-instance
 /// buffered `.append` to the clone.
 pub fn prepared_base(store: &Store, read: ReadMode, direct_write: bool) -> Result<Engine, Error> {
-    // Clone the embedder-provided base (its context-free commands, env, and
-    // consts) when one is set, so every processor engine branches from it;
-    // otherwise build the default base. See the "Engine tree" note: prepare the
-    // base once, clone per use.
+    // Clone the embedder's base engine when the store carries one, else build
+    // the default. See ADR 0007.
     let mut engine = match store.base_engine() {
         Some(base) => Engine {
             state: base.clone(),

--- a/src/nu/mod.rs
+++ b/src/nu/mod.rs
@@ -13,6 +13,8 @@ pub use util::{frame_to_pipeline, frame_to_value, value_to_json};
 pub use vfs::load_modules;
 
 #[cfg(test)]
+mod test_base_engine;
+#[cfg(test)]
 mod test_commands;
 #[cfg(test)]
 mod test_engine;

--- a/src/nu/test_base_engine.rs
+++ b/src/nu/test_base_engine.rs
@@ -1,0 +1,75 @@
+use tempfile::TempDir;
+
+use nu_protocol::engine::{Call, Command, EngineState, Stack};
+use nu_protocol::{Category, PipelineData, ShellError, Signature};
+
+use crate::nu::{prepared_base, Engine, ReadMode};
+use crate::store::Store;
+
+/// A trivial marker command standing in for a consumer-registered command like
+/// http-nu's `.mj`. It must survive from a store's base engine into the engine
+/// a processor builds via `prepared_base`.
+#[derive(Clone)]
+struct MarkerCommand;
+
+impl Command for MarkerCommand {
+    fn name(&self) -> &str {
+        "xs-base-marker"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("xs-base-marker").category(Category::Custom("test".into()))
+    }
+
+    fn description(&self) -> &str {
+        "test marker command carried on a base engine"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        _call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(PipelineData::empty())
+    }
+}
+
+/// A command an embedder puts on the store's base engine must resolve in the
+/// engine a processor builds via `prepared_base`.
+#[test]
+fn prepared_base_carries_store_base_engine_commands() {
+    let temp = TempDir::new().unwrap();
+
+    let mut base = Engine::new().unwrap();
+    base.add_commands(vec![Box::new(MarkerCommand)]).unwrap();
+
+    let store = Store::new(temp.path().to_path_buf())
+        .unwrap()
+        .with_base_engine(base.state);
+
+    let engine = prepared_base(&store, ReadMode::Stream, true).unwrap();
+    assert!(
+        engine
+            .eval(PipelineData::empty(), "xs-base-marker".to_string())
+            .is_ok(),
+        "a command from the store's base engine should resolve in a processor engine"
+    );
+}
+
+/// With no base set, `prepared_base` still yields a usable engine (the default
+/// base plus the store builtins).
+#[test]
+fn prepared_base_without_base_engine_still_builds() {
+    let temp = TempDir::new().unwrap();
+    let store = Store::new(temp.path().to_path_buf()).unwrap();
+
+    let engine = prepared_base(&store, ReadMode::Stream, true).unwrap();
+    assert!(
+        engine
+            .eval(PipelineData::empty(), "echo hi".to_string())
+            .is_ok(),
+        "default prepared_base should still produce a usable engine"
+    );
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -34,6 +34,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use std::sync::{Arc, Mutex};
 
+use nu_protocol::engine::EngineState;
 use scru128::Scru128Id;
 
 use serde::{Deserialize, Deserializer, Serialize};
@@ -459,6 +460,12 @@ pub struct Store {
     broadcast_tx: broadcast::Sender<Frame>,
     gc_tx: UnboundedSender<GCTask>,
     append_lock: Arc<Mutex<()>>,
+    /// Optional base engine an embedder prepares (its own context-free commands,
+    /// environment, and consts) for every Nushell engine the processors build.
+    /// Shared across `Store` clones; `None` falls back to the default
+    /// `Engine::new()`. See [`prepared_base`](crate::nu::prepared_base) and the
+    /// "Engine tree" architecture note.
+    base_engine: Option<Arc<EngineState>>,
 }
 
 impl Store {
@@ -519,12 +526,32 @@ impl Store {
             broadcast_tx,
             gc_tx,
             append_lock: Arc::new(Mutex::new(())),
+            base_engine: None,
         };
 
         // Spawn gc worker thread
         spawn_gc_worker(gc_rx, store.clone());
 
         Ok(store)
+    }
+
+    /// Attach a base engine that every processor engine is cloned from.
+    ///
+    /// An embedder (for example http-nu) prepares an [`EngineState`] with its
+    /// own context-free commands, environment, and consts and hands it over
+    /// here. [`prepared_base`](crate::nu::prepared_base) then clones this base
+    /// per spawn and layers the store commands on top, so actors, services, and
+    /// actions all see the embedder's commands. With no base set, the default
+    /// `Engine::new()` is used. The base is shared across `Store` clones, so set
+    /// it once, before spawning the processors.
+    pub fn with_base_engine(mut self, base: EngineState) -> Self {
+        self.base_engine = Some(Arc::new(base));
+        self
+    }
+
+    /// The base engine an embedder attached via [`with_base_engine`], if any.
+    pub fn base_engine(&self) -> Option<&EngineState> {
+        self.base_engine.as_deref()
     }
 
     /// Wait until the background garbage-collection worker has processed every

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -460,11 +460,9 @@ pub struct Store {
     broadcast_tx: broadcast::Sender<Frame>,
     gc_tx: UnboundedSender<GCTask>,
     append_lock: Arc<Mutex<()>>,
-    /// Optional base engine an embedder prepares (its own context-free commands,
-    /// environment, and consts) for every Nushell engine the processors build.
-    /// Shared across `Store` clones; `None` falls back to the default
-    /// `Engine::new()`. See [`prepared_base`](crate::nu::prepared_base) and the
-    /// "Engine tree" architecture note.
+    /// Optional base engine the processors clone, set via [`with_base_engine`].
+    /// `None` falls back to `Engine::new()`. See
+    /// [`prepared_base`](crate::nu::prepared_base) and ADR 0007.
     base_engine: Option<Arc<EngineState>>,
 }
 
@@ -535,15 +533,14 @@ impl Store {
         Ok(store)
     }
 
-    /// Attach a base engine that every processor engine is cloned from.
+    /// Set a base engine the processor engines clone.
     ///
-    /// An embedder (for example http-nu) prepares an [`EngineState`] with its
-    /// own context-free commands, environment, and consts and hands it over
-    /// here. [`prepared_base`](crate::nu::prepared_base) then clones this base
-    /// per spawn and layers the store commands on top, so actors, services, and
-    /// actions all see the embedder's commands. With no base set, the default
-    /// `Engine::new()` is used. The base is shared across `Store` clones, so set
-    /// it once, before spawning the processors.
+    /// A program that embeds xs prepares an [`EngineState`] with its own
+    /// commands, env, and consts;
+    /// [`prepared_base`](crate::nu::prepared_base) clones it per spawn and adds
+    /// the store commands, so the actor, service, and action processors get
+    /// those commands. Shared across `Store` clones, so set it once, before the
+    /// processors spawn. No base set: `Engine::new()`.
     pub fn with_base_engine(mut self, base: EngineState) -> Self {
         self.base_engine = Some(Arc::new(base));
         self


### PR DESCRIPTION
## What

`Store::with_base_engine(EngineState)` lets an embedder set a base engine the processors clone. `prepared_base` clones it (or the default `Engine::new()`), then layers the store commands. No base set: behaviour unchanged.

## Why

`prepared_base` gave embedders nowhere to add commands, so http-nu's `.mj` never reached services or actors. `EngineState` is the shared type, so http-nu builds a base and hands it over.

## Notes

- Model: ADR 0007 (prepare a base once, clone per subsystem).
- Test: `src/nu/test_base_engine.rs`. Suite green.
- http-nu #48 builds on this.
- `check.sh` clippy flags pre-existing `result_large_err` in untouched `cat_stream_command.rs` (stable 1.96 vs MSRV 1.93.1); CI's non-strict clippy is unaffected.
