### PR TITLE
fix: round scru128 timestamp on pack to stop id roundtrip loss

### DIFF
--- a/src/nu/test_commands.rs
+++ b/src/nu/test_commands.rs
@@ -555,22 +555,43 @@ mod tests {
         assert!(scru128::Scru128Id::from_str(id_string).is_ok()); // Verify it's a valid SCRU128 ID
     }
 
+    fn assert_id_roundtrips(engine: &crate::nu::Engine, id: &str) {
+        let unpacked = nu_eval(
+            engine,
+            PipelineData::empty(),
+            format!("\"{}\" | .id unpack", id),
+        );
+        let repacked = nu_eval(engine, PipelineData::Value(unpacked, None), ".id pack");
+        assert_eq!(
+            id,
+            repacked.as_str().unwrap(),
+            "roundtrip mismatch for {id}"
+        );
+    }
+
     #[test]
     fn test_scru128_round_trip() {
         let engine = setup_scru128_test_env();
 
-        let original_id = nu_eval(&engine, PipelineData::empty(), ".id");
-        let original_id_str = original_id.as_str().unwrap();
+        // Pinned ids that lost 1ms of timestamp before the round fix. The
+        // unpack seconds -> datetime -> pack path truncated milliseconds
+        // instead of rounding, so ids whose f64 ms landed just below an
+        // integer dropped a millisecond and repacked to a different id.
+        for id in [
+            "03gmmrhqljv8bnulus79wipck",
+            "03gmmrhqzjzlbz75e1r8fyvmt",
+            "03gmmrhsh0x17va0knqvbhly6",
+        ] {
+            assert_id_roundtrips(&engine, id);
+        }
 
-        let unpacked = nu_eval(
-            &engine,
-            PipelineData::empty(),
-            format!("\"{}\" | .id unpack", original_id_str),
-        );
-        let repacked = nu_eval(&engine, PipelineData::Value(unpacked, None), ".id pack");
-        let repacked_id_str = repacked.as_str().unwrap();
-
-        assert_eq!(original_id_str, repacked_id_str);
+        // Deterministic sweep: every fresh id must roundtrip exactly. Before
+        // the fix this failed on roughly 3% of ids, so 2000 makes a failure
+        // essentially certain rather than a ~1-in-35 flake.
+        for _ in 0..2000 {
+            let id = nu_eval(&engine, PipelineData::empty(), ".id");
+            assert_id_roundtrips(&engine, id.as_str().unwrap());
+        }
     }
 
     #[test]

--- a/src/scru128.rs
+++ b/src/scru128.rs
@@ -68,7 +68,7 @@ pub fn pack_from_json(
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let components: Scru128Components = serde_json::from_value(json)?;
 
-    let timestamp = (components.timestamp * 1000.0) as u64;
+    let timestamp = (components.timestamp * 1000.0).round() as u64;
     let entropy = u32::from_str_radix(&components.node, 16)?;
 
     let scru_id = Scru128Id::from_fields(
@@ -87,7 +87,7 @@ pub fn pack() -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
 
     let components: Scru128Components = serde_json::from_str(&buffer)?;
 
-    let timestamp = (components.timestamp * 1000.0) as u64;
+    let timestamp = (components.timestamp * 1000.0).round() as u64;
     let entropy = u32::from_str_radix(&components.node, 16)?;
 
     let scru_id = Scru128Id::from_fields(

--- a/tests/test_xs_nu.nu
+++ b/tests/test_xs_nu.nu
@@ -43,6 +43,27 @@ use ../xs.nu *
   let new_id = (.id)
   .id unpack $new_id | .id pack | assert-eq $new_id ".id roundtrip"
 
+  # pinned ids that lost low-order timestamp bits before the round fix.
+  # the unpack seconds -> datetime -> pack path truncated ms instead of
+  # rounding, so ids whose f64 ms landed just under an integer dropped 1ms.
+  let pinned = [
+    03gmmrhqljv8bnulus79wipck
+    03gmmrhqzjzlbz75e1r8fyvmt
+    03gmmrhsh0x17va0knqvbhly6
+  ]
+  for id in $pinned {
+    .id unpack $id | .id pack | assert-eq $id $".id roundtrip pinned ($id)"
+  }
+
+  # deterministic loop: many fresh ids must roundtrip exactly.
+  # before the fix this failed on roughly 3% of ids.
+  let failures = (1..2000 | each {|_|
+    let id = (.id)
+    let back = (.id unpack $id | .id pack)
+    if $back != $id { {id: $id, back: $back} } else { null }
+  } | compact)
+  $failures | length | assert-eq 0 $".id roundtrip loop failures: ($failures)"
+
   # test metadata
   "with meta" | .append meta-topic --meta {key: "value"}
   .last meta-topic | get meta.key | assert-eq "value" "metadata"


### PR DESCRIPTION
## Problem

`.id unpack $id | .id pack` did not roundtrip for about 3% of scru128 ids. The prefix matched and the low bits diverged, for example:

```
03gmmrhqljv8bnulus79wipck -> 03gmmrhqleed8w8bsl6cn17tg
```

This is what made the `.id roundtrip` assertion in `tests/test_xs_nu.nu` flaky, since it minted one fresh id per run and tripped roughly 1 run in 35.

## Mechanism

`.id unpack` emits the timestamp as f64 seconds (`scru128.rs`, ms / 1000.0) and the nu def routes it through a nanosecond datetime. `.id pack` hands f64 seconds back to the Rust packer, which computed milliseconds with `(timestamp * 1000.0) as u64`. The `as u64` cast truncates toward zero. When the reconstructed f64 millisecond value landed just under an integer (for example `1785966646157.9998` for a true `1785966646158`), it dropped a millisecond. That corrupts the 48-bit timestamp field and repacks to a different id.

## Fix

Round to the nearest millisecond instead of truncating, in both `pack_from_json` and `pack` (`src/scru128.rs`). The nu datetime detour keeps the value within sub-nanosecond of the true millisecond, so rounding recovers it exactly.

## Tests

Both roundtrip tests now pin the known failing ids and sweep 2000 fresh ids per run, replacing the single random-id check. Measured loop failures: 56/2000 before, 0/2000 after. The Rust `test_scru128_round_trip` and the e2e `tests/test_xs_nu.nu` both fail reliably on the old code and pass on the fix.

`cargo fmt`, `cargo clippy -D warnings`, and `cargo test` are green. The `docs` (astro) step of `check.sh` requires Node >=22.12 and is not run here (local Node is 18.19.1); that is an environment gate, unrelated to this change.