### PR TITLE
test: stop test_topics_filter_pulse_still_ticks flaking on interleaved pulse ticks

### DIFF
--- a/src/processor/actor/tests.rs
+++ b/src/processor/actor/tests.rs
@@ -2117,19 +2117,34 @@ async fn test_topics_filter_pulse_still_ticks() {
     assert_eq!(out.topic, "filter.out");
     assert_eq!(out.meta.as_ref().unwrap()["tick"], true);
 
-    // And filtered frames still flow alongside the pulse
+    // And filtered frames still flow alongside the pulse.
+    //
+    // Wait past one pulse period (pulse is 50ms) before appending so a second
+    // tick is guaranteed to be emitted ahead of the data frames. This forces
+    // the interleave that only happened by luck on slow CI runners, making the
+    // tick-between-data-frames case deterministic on any machine.
+    tokio::time::sleep(std::time::Duration::from_millis(60)).await;
     store.append(Frame::builder("noise").build()).unwrap();
     store.append(Frame::builder("ev").build()).unwrap();
-    assert_eq!(recver.recv().await.unwrap().topic, "noise");
-    assert_eq!(recver.recv().await.unwrap().topic, "ev");
-    loop {
-        let out = recver.recv().await.unwrap();
-        assert_eq!(out.topic, "filter.out");
-        let meta = out.meta.as_ref().unwrap();
-        if meta.get("tick").is_some() {
-            continue; // interleaved pulse ticks are fine
+
+    // Pulse ticks are async and can land between the data frames, so the exact
+    // interleaving is not fixed. Drain any tick frames and assert only that the
+    // three frames we care about arrive: "noise" then "ev" in append order, and
+    // the actor's own "filter.out {seen: ev}" output.
+    let mut data_topics = Vec::new();
+    let mut saw_seen_ev = false;
+    while !saw_seen_ev {
+        let frame = recver.recv().await.unwrap();
+        if frame.topic == "filter.out" {
+            let meta = frame.meta.as_ref().unwrap();
+            if meta.get("tick").is_some() {
+                continue; // interleaved pulse ticks are fine
+            }
+            assert_eq!(meta["seen"], "ev");
+            saw_seen_ev = true;
+        } else {
+            data_topics.push(frame.topic);
         }
-        assert_eq!(meta["seen"], "ev");
-        break;
     }
+    assert_eq!(data_topics, vec!["noise", "ev"]);
 }


### PR DESCRIPTION
## What flaked and why

`test_topics_filter_pulse_still_ticks` failed on the windows and macos CI runners while passing on ubuntu and local Linux.

The actor under test is configured with `pulse: 50`, so it emits a `filter.out` frame with `tick: true` every 50ms. The test consumed the first tick, then appended `noise` and `ev` and asserted the recv order was exactly `noise` then `ev`:

```rust
store.append(Frame::builder("noise").build()).unwrap();
store.append(Frame::builder("ev").build()).unwrap();
assert_eq!(recver.recv().await.unwrap().topic, "noise"); // got "filter.out" on slow runners
assert_eq!(recver.recv().await.unwrap().topic, "ev");
```

On a slow runner, more than 50ms passed between consuming the first tick and this recv, so a second pulse tick landed in the store ahead of `noise` and the strict `assert_eq!(... "noise")` got `filter.out` instead. The actor is behaving correctly: async pulse ticks interleave with data frames, and the order between a tick and a data frame is not guaranteed. The loop further down already tolerated interleaved ticks; these two asserts did not.

## Deterministic repro

Sleep 60ms (past one 50ms pulse period) after consuming the first tick and before appending, so a second tick is always queued ahead of the data frames on any machine. With that in place the old strict asserts fail deterministically (`assertion left == right failed, left: "filter.out", right: "noise"`), matching CI.

## The fix

Keep the forced interleave so the test genuinely exercises the tick-between-data-frames case going forward, and tolerate ticks the same way the loop already did: drain `filter.out` tick frames, then assert only that `noise` and `ev` arrive in append order and the actor's `filter.out {seen: ev}` output arrives.

## Verification

- `cargo test`: 189 + 12 + 8 passed, 0 failed
- `processor::actor::tests` module: 35 passed
- `cargo fmt --check` and `cargo clippy -- -D warnings`: clean
- `nu tests/test_xs_nu.nu`: a pre-existing scru128 id-roundtrip failure reproduces on a clean checkout of this branch's base too, unrelated to this change
- docs/astro step in `check.sh` needs Node >=22.12.0; the local Node is v18.19.1, so that step is gated by the environment (unrelated to this change)