### PR TITLE
refactor: carry scru128 timestamp as integer milliseconds

### DIFF
--- a/examples/discord-bot/actor-heartbeat.nu
+++ b/examples/discord-bot/actor-heartbeat.nu
@@ -48,8 +48,8 @@ def "op resume" [token: string, session_id: string, seq: int] {
 ### end op.nu
 
 def "scru128-since" [$id1, $id2] {
-    let t1 = ($id1 | .id unpack | get timestamp)
-    let t2 = ($id2 | .id unpack | get timestamp)
+    let t1 = ($id1 | .id unpack | get when)
+    let t2 = ($id2 | .id unpack | get when)
     return ($t1 - $t2)
 }
 

--- a/src/nu/commands/scru128_command.rs
+++ b/src/nu/commands/scru128_command.rs
@@ -57,28 +57,24 @@ fn get_record_input(
     }
 }
 
-// Helper function to convert timestamp field to datetime
-fn convert_timestamp_to_datetime(mut nu_value: Value, span: nu_protocol::Span) -> Value {
-    if let Value::Record { val: record, .. } = &mut nu_value {
-        if let Some(Value::Float {
-            val: timestamp_float,
-            ..
-        }) = record.get("timestamp")
-        {
-            let timestamp_ms = (*timestamp_float * 1000.0) as i64;
-            let datetime_value = Value::date(
-                chrono::DateTime::from_timestamp_millis(timestamp_ms)
+// Add a display-only `when` datetime derived from the authoritative `ts_ms`
+// integer. `when` is for reading; pack ignores it and uses `ts_ms`.
+fn add_when_field(nu_value: Value, span: nu_protocol::Span) -> Value {
+    if let Value::Record { val: record, .. } = &nu_value {
+        if let Some(Value::Int { val: ts_ms, .. }) = record.get("ts_ms") {
+            let when = Value::date(
+                chrono::DateTime::from_timestamp_millis(*ts_ms)
                     .unwrap_or_else(chrono::Utc::now)
                     .into(),
                 span,
             );
-            // Create new record with updated timestamp
+            // Insert `when` right after `ts_ms` so the reading order stays
+            // ts_ms, when, counters, node.
             let mut new_record = Record::new();
             for (key, value) in record.iter() {
-                if key == "timestamp" {
-                    new_record.push(key.clone(), datetime_value.clone());
-                } else {
-                    new_record.push(key.clone(), value.clone());
+                new_record.push(key.clone(), value.clone());
+                if key == "ts_ms" {
+                    new_record.push("when".to_string(), when.clone());
                 }
             }
             return Value::record(new_record, span);
@@ -87,31 +83,12 @@ fn convert_timestamp_to_datetime(mut nu_value: Value, span: nu_protocol::Span) -
     nu_value
 }
 
-// Helper function to convert datetime fields to timestamp floats in JSON
-#[allow(clippy::result_large_err)]
-fn convert_datetime_to_timestamp(
-    mut json_value: JsonValue,
-    span: nu_protocol::Span,
-) -> Result<JsonValue, ShellError> {
+// Drop the display-only `when` field before packing. Pack reads `ts_ms` alone.
+fn drop_when_field(mut json_value: JsonValue) -> JsonValue {
     if let JsonValue::Object(ref mut obj) = json_value {
-        if let Some(JsonValue::String(timestamp_str)) = obj.get("timestamp") {
-            if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(timestamp_str) {
-                let timestamp_float = datetime.timestamp_millis() as f64 / 1000.0;
-                obj.insert(
-                    "timestamp".to_string(),
-                    JsonValue::Number(serde_json::Number::from_f64(timestamp_float).ok_or_else(
-                        || {
-                            scru128_error(
-                                "Could not convert datetime to timestamp".to_string(),
-                                span,
-                            )
-                        },
-                    )?),
-                );
-            }
-        }
+        obj.remove("when");
     }
-    Ok(json_value)
+    json_value
 }
 
 #[derive(Clone, Default)]
@@ -171,14 +148,14 @@ impl Command for Scru128Command {
                     .map_err(|e| scru128_error(format!("Failed to unpack ID: {e}"), span))?;
 
                 let nu_value = util::json_to_value(&result, span);
-                let nu_value = convert_timestamp_to_datetime(nu_value, span);
+                let nu_value = add_when_field(nu_value, span);
 
                 Ok(PipelineData::Value(nu_value, None))
             }
             Some("pack") => {
                 let components = get_record_input(call, engine_state, stack, input, span)?;
                 let json_value = util::value_to_json(&components);
-                let json_value = convert_datetime_to_timestamp(json_value, span)?;
+                let json_value = drop_when_field(json_value);
 
                 let result = crate::scru128::pack_from_json(json_value)
                     .map_err(|e| scru128_error(format!("Failed to pack components: {e}"), span))?;

--- a/src/nu/test_commands.rs
+++ b/src/nu/test_commands.rs
@@ -494,13 +494,35 @@ mod tests {
         let record = unpacked.as_record().unwrap();
 
         // Verify expected fields are present
-        assert!(record.get("timestamp").is_some());
+        assert!(record.get("ts_ms").is_some());
+        assert!(record.get("when").is_some());
         assert!(record.get("counter_hi").is_some());
         assert!(record.get("counter_lo").is_some());
         assert!(record.get("node").is_some());
 
-        // Verify timestamp is a datetime
-        assert!(record.get("timestamp").unwrap().as_date().is_ok());
+        // ts_ms is the authoritative integer millisecond timestamp.
+        assert!(record.get("ts_ms").unwrap().as_int().is_ok());
+        // when is a display-only datetime derived from ts_ms.
+        assert!(record.get("when").unwrap().as_date().is_ok());
+    }
+
+    #[test]
+    fn test_scru128_unpack_when_matches_ts_ms() {
+        let engine = setup_scru128_test_env();
+        let test_id = "03d4q1qhbiv09ovtuhokw5yxv";
+        let unpacked = nu_eval(
+            &engine,
+            PipelineData::empty(),
+            format!(".id unpack {}", test_id),
+        );
+        let record = unpacked.as_record().unwrap();
+
+        // The display-only when field must read back the same instant as the
+        // authoritative ts_ms, so a future change cannot silently drop or skew
+        // the human-readable view.
+        let ts_ms = record.get("ts_ms").unwrap().as_int().unwrap();
+        let when = record.get("when").unwrap().as_date().unwrap();
+        assert_eq!(ts_ms, when.timestamp_millis());
     }
 
     #[test]
@@ -516,8 +538,11 @@ mod tests {
         assert!(unpacked.as_record().is_ok());
         let record = unpacked.as_record().unwrap();
 
-        // Verify expected fields are present
-        assert!(record.get("timestamp").is_some());
+        // The pipeline form emits the same record as the row form: ts_ms is the
+        // authoritative integer millisecond timestamp, when is the display-only
+        // datetime derived from it.
+        assert!(record.get("ts_ms").unwrap().as_int().is_ok());
+        assert!(record.get("when").unwrap().as_date().is_ok());
         assert!(record.get("counter_hi").is_some());
         assert!(record.get("counter_lo").is_some());
         assert!(record.get("node").is_some());
@@ -527,7 +552,7 @@ mod tests {
     fn test_scru128_pack() {
         let engine = setup_scru128_test_env();
         let components =
-            r#"{timestamp: (date now), counter_hi: 1234, counter_lo: 5678, node: "abcd1234"}"#;
+            r#"{ts_ms: 1700000000000, counter_hi: 1234, counter_lo: 5678, node: "abcd1234"}"#;
         let packed = nu_eval(
             &engine,
             PipelineData::empty(),
@@ -542,8 +567,8 @@ mod tests {
     #[test]
     fn test_scru128_pack_pipeline() {
         let engine = setup_scru128_test_env();
-        let components =
-            r#"{timestamp: (date now), counter_hi: 1234, counter_lo: 5678, node: "abcd1234"}"#;
+        // when is display-only; pack must ignore it and use ts_ms.
+        let components = r#"{ts_ms: 1700000000000, when: (date now), counter_hi: 1234, counter_lo: 5678, node: "abcd1234"}"#;
         let packed = nu_eval(
             &engine,
             PipelineData::empty(),

--- a/src/scru128.rs
+++ b/src/scru128.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct Scru128Components {
-    timestamp: f64,
+    ts_ms: u64,
     counter_hi: u32,
     counter_lo: u32,
     node: String,
@@ -15,6 +15,28 @@ struct Scru128Components {
 pub fn generate() -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let id = scru128::new();
     Ok(id.to_string())
+}
+
+fn components_of(scru_id: Scru128Id) -> Scru128Components {
+    Scru128Components {
+        ts_ms: scru_id.timestamp(),
+        counter_hi: scru_id.counter_hi(),
+        counter_lo: scru_id.counter_lo(),
+        node: format!("{:08x}", scru_id.entropy()),
+    }
+}
+
+fn id_of(
+    components: Scru128Components,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let entropy = u32::from_str_radix(&components.node, 16)?;
+    let scru_id = Scru128Id::from_fields(
+        components.ts_ms,
+        components.counter_hi,
+        components.counter_lo,
+        entropy,
+    );
+    Ok(scru_id.to_string())
 }
 
 pub fn unpack(input: &str) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
@@ -27,58 +49,21 @@ pub fn unpack(input: &str) -> Result<String, Box<dyn std::error::Error + Send + 
     };
 
     let scru_id = Scru128Id::from_str(&id)?;
-
-    let timestamp = scru_id.timestamp() as f64 / 1000.0;
-    let counter_hi = scru_id.counter_hi();
-    let counter_lo = scru_id.counter_lo();
-    let node = format!("{:08x}", scru_id.entropy());
-
-    let components = Scru128Components {
-        timestamp,
-        counter_hi,
-        counter_lo,
-        node,
-    };
-
-    Ok(serde_json::to_string_pretty(&components)?)
+    Ok(serde_json::to_string_pretty(&components_of(scru_id))?)
 }
 
 pub fn unpack_to_json(
     input: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
     let scru_id = Scru128Id::from_str(input)?;
-
-    let timestamp = scru_id.timestamp() as f64 / 1000.0;
-    let counter_hi = scru_id.counter_hi();
-    let counter_lo = scru_id.counter_lo();
-    let node = format!("{:08x}", scru_id.entropy());
-
-    let components = Scru128Components {
-        timestamp,
-        counter_hi,
-        counter_lo,
-        node,
-    };
-
-    Ok(serde_json::to_value(components)?)
+    Ok(serde_json::to_value(components_of(scru_id))?)
 }
 
 pub fn pack_from_json(
     json: serde_json::Value,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let components: Scru128Components = serde_json::from_value(json)?;
-
-    let timestamp = (components.timestamp * 1000.0).round() as u64;
-    let entropy = u32::from_str_radix(&components.node, 16)?;
-
-    let scru_id = Scru128Id::from_fields(
-        timestamp,
-        components.counter_hi,
-        components.counter_lo,
-        entropy,
-    );
-
-    Ok(scru_id.to_string())
+    id_of(components)
 }
 
 pub fn pack() -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
@@ -86,16 +71,5 @@ pub fn pack() -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     io::stdin().read_to_string(&mut buffer)?;
 
     let components: Scru128Components = serde_json::from_str(&buffer)?;
-
-    let timestamp = (components.timestamp * 1000.0).round() as u64;
-    let entropy = u32::from_str_radix(&components.node, 16)?;
-
-    let scru_id = Scru128Id::from_fields(
-        timestamp,
-        components.counter_hi,
-        components.counter_lo,
-        entropy,
-    );
-
-    Ok(scru_id.to_string())
+    id_of(components)
 }

--- a/xs.nu
+++ b/xs.nu
@@ -228,8 +228,17 @@ export def ".id unpack" [id?: string] {
     error make {msg: "No ID provided as argument or via pipeline"}
   }
 
+  # ts_ms is the authoritative integer millisecond timestamp that pack reads
+  # back exactly. when is a display-only datetime derived from it, ignored by
+  # pack, so the roundtrip stays lossless.
   let components = xs scru128 unpack $input_id | from json
-  $components | update timestamp ($components.timestamp * 1000000000 | into int | into datetime)
+  {
+    ts_ms: $components.ts_ms
+    when: ($components.ts_ms * 1000000 | into int | into datetime)
+    counter_hi: $components.counter_hi
+    counter_lo: $components.counter_lo
+    node: $components.node
+  }
 }
 
 # Pack component fields into a SCRU128 ID
@@ -239,10 +248,9 @@ export def ".id pack" [components?: record] {
     error make {msg: "No components provided as argument or via pipeline"}
   }
 
+  # Drop the display-only when field; ts_ms is authoritative.
   $input_components
-  | conditional-pipe (($input_components.timestamp | describe) == "datetime") {
-    update timestamp ($input_components.timestamp | into int | $in / 1000000000)
-  }
+  | reject when?
   | to json
   | xs scru128 pack
 }


### PR DESCRIPTION
## Problem

A scru128 timestamp is an exact 48-bit integer count of milliseconds. `.id unpack`/`.id pack` turned it into f64 seconds and routed it through a nanosecond datetime, and that float detour lost a millisecond on about 3% of ids. A `.round()` guard patched the final truncation, but the type was still wrong.

## Change

Carry the timestamp as an integer, the same kind of value the counters and entropy already are.

- `src/scru128.rs`: `Components.timestamp` becomes `ts_ms: u64`. `unpack` emits `scru_id.timestamp()` directly and `pack` consumes it directly, so there is no float and no rounding in the path. Decompose and recompose are consolidated into `components_of` and `id_of`.
- `.id unpack` returns `ts_ms` as the authoritative field, plus a display-only `when` datetime derived from it. `.id pack` drops `when` and packs from `ts_ms`. The roundtrip is lossless by construction, so the `.round()` guard is removed.
- `pack` stays, for constructing an id from chosen parts.
- The one caller that read the old `.timestamp` field, `examples/discord-bot/actor-heartbeat.nu`, now reads `when`.

## Tests

The `.id` roundtrip sweep and the pinned-id fixtures from the prior fix stay and pass. Added `test_scru128_unpack_when_matches_ts_ms`, checking that `when` reads back the same instant as `ts_ms`. All 8 scru128 unit tests pass.
