### PR TITLE
fix: run xs.stopping on SIGTERM and Windows console-close, not just ctrl-c

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -374,13 +374,32 @@ async fn serve(args: CommandServe) -> Result<(), Box<dyn std::error::Error + Sen
 
     tokio::select! {
         res = xs::api::serve(store.clone(), engine.clone(), args.expose) => { res?; }
-        _ = tokio::signal::ctrl_c() => {}
+        _ = shutdown_signal() => {}
     }
 
     store.append(xs::store::Frame::builder("xs.stopping").build())?;
     let _ = tokio::time::timeout(Duration::from_secs(3), service_handle).await;
 
     Ok(())
+}
+
+// Both SIGINT and SIGTERM must run the xs.stopping protocol: supervisors send
+// SIGTERM, and without the protocol service-spawned children leak.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm =
+            signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 async fn cat(args: CommandCat) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,9 +396,22 @@ async fn shutdown_signal() {
             _ = sigterm.recv() => {}
         }
     }
-    #[cfg(not(unix))]
+    // Windows has no SIGTERM. ctrl_close fires when the console window is
+    // closed (a supervisor gets ~5s before Windows force-kills), ctrl_shutdown
+    // fires on system shutdown/logoff -- both are the closest analogs to
+    // "asked to terminate, clean up first". ctrl_close only reaches console
+    // processes, not services stopped via SERVICE_CONTROL_STOP, so this is
+    // best-effort console coverage, not full service support.
+    #[cfg(windows)]
     {
-        let _ = tokio::signal::ctrl_c().await;
+        use tokio::signal::windows::{ctrl_close, ctrl_shutdown};
+        let mut close = ctrl_close().expect("failed to install CTRL_CLOSE handler");
+        let mut shutdown = ctrl_shutdown().expect("failed to install CTRL_SHUTDOWN handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = close.recv() => {}
+            _ = shutdown.recv() => {}
+        }
     }
 }
 


### PR DESCRIPTION
`xs serve` ran its `xs.stopping` shutdown only on ctrl-c (SIGINT). Stop the server any other way and it skipped that shutdown, leaving the service processor's child processes running after exit.

A new `shutdown_signal()` helper covers the ways a process actually gets asked to stop:

- **Unix:** SIGTERM, which is what systemd and most supervisors send, now runs the same shutdown as ctrl-c.
- **Windows:** there is no SIGTERM, so it also listens for `ctrl_close` (console window closed) and `ctrl_shutdown` (system shutdown or logoff).

**For reviewers**

On Windows, `CTRL_CLOSE` only reaches a process that owns a console, not a service stopped through `SERVICE_CONTROL_STOP`. So the Windows side is best-effort console coverage, not full service support; CI's `windows-amd64` job compiles and runs it.

On Unix I sent a real SIGTERM to a running `xs serve` and confirmed the `xs.stopping` frame lands and the process exits cleanly, the same as ctrl-c. `cargo test --lib` (189 passed) and `cargo clippy` are clean.
